### PR TITLE
Multistep conversion

### DIFF
--- a/featurex/converters/__init__.py
+++ b/featurex/converters/__init__.py
@@ -82,7 +82,7 @@ def get_converter(in_type, out_type):
     transformers = get_subclasses(base)
     for a in transformers:
         concrete = len(a.__abstractmethods__) == 0
-        if a._input_type == in_type and a._output_type == out_type and concrete:
+        if concrete and issubclass(in_type, a._input_type) and issubclass(out_type, a._output_type):
             try:
                 conv = a()
                 return conv

--- a/featurex/converters/__init__.py
+++ b/featurex/converters/__init__.py
@@ -1,6 +1,7 @@
 from abc import ABCMeta, abstractmethod, abstractproperty
 from featurex.transformers import Transformer, CollectionStimMixin
 from six import with_metaclass
+import importlib
 
 __all__ = ['api', 'audio', 'google', 'image', 'video']
 
@@ -33,3 +34,59 @@ class Converter(with_metaclass(ABCMeta, Transformer)):
     def _transform(self, stim, *args, **kwargs):
         return self.convert(stim, *args, **kwargs)
 
+
+class MultistepConverter(Converter):
+    ''' Base class for Converters doing more than one step.
+    Args:
+        via (list): Ordered sequence of types to convert through
+    '''
+
+    def __init__(self, via=None):
+        super(MultistepConverter, self).__init__()
+        self.via = self._via if via is None else via
+
+    def _convert(self, stim):
+        for i, step in enumerate(self.via):
+            converter = get_converter(type(stim), step)
+            if converter:
+                stim = converter.transform(stim)
+            else:
+                msg = "Conversion failed during step %d" % i
+                raise ValueError(msg)
+        return stim
+
+
+def get_converter(in_type, out_type):
+    ''' Scans the list of available Converters and returns an instantiation
+    of the first one whose input and output types match those passed in.
+    Args:
+        in_type (type): The type of input the converter must have.
+        out_type (type): The type of output the converter must have.
+    '''
+
+    # Recursively get all classes that inherit from the passed base class
+    def get_subclasses(cls):
+        subclasses = []
+        for sc in cls.__subclasses__():
+            subclasses.append(sc)
+            subclasses.extend(get_subclasses(sc))
+        return subclasses
+
+    base = Converter
+
+    bm = base.__module__
+    submods = importlib.import_module(bm).__all__
+    sources = ['%s.%s' % (bm, sm) for sm in submods]
+    [importlib.import_module(s) for s in sources]
+
+    transformers = get_subclasses(base)
+    for a in transformers:
+        concrete = len(a.__abstractmethods__) == 0
+        if a._input_type == in_type and a._output_type == out_type and concrete:
+            try:
+                conv = a()
+                return conv
+            except ValueError:
+                # Important for API converters
+                pass
+    return None

--- a/featurex/converters/video.py
+++ b/featurex/converters/video.py
@@ -1,9 +1,16 @@
 from featurex.stimuli.video import VideoStim, DerivedVideoStim, VideoFrameStim
 from featurex.stimuli.audio import AudioStim
-from featurex.converters import Converter
+from featurex.stimuli.text import TextStim
+from featurex.converters import Converter, MultistepConverter
 
 import pandas as pd
 import os
+
+
+class VideoToTextConverter(MultistepConverter):
+    _input_type = VideoStim
+    _output_type = TextStim
+    _via = [AudioStim, TextStim]
 
 
 class VideoToAudioConverter(Converter):

--- a/featurex/tests/test_converters.py
+++ b/featurex/tests/test_converters.py
@@ -1,6 +1,8 @@
 from os.path import join, splitext
 from .utils import get_test_data_path
-from featurex.converters.video import FrameSamplingConverter, VideoToAudioConverter
+from featurex.converters.video import (FrameSamplingConverter, 
+                                        VideoToAudioConverter, 
+                                        VideoToTextConverter)
 from featurex.converters.image import TesseractConverter
 from featurex.converters.api import (WitTranscriptionConverter, 
                                         GoogleSpeechAPIConverter,
@@ -131,3 +133,13 @@ def test_google_vision_api_text_converter():
     text = conv.transform(stim).text
     assert 'Exit' in text
 
+
+@pytest.mark.skipif("'WIT_AI_API_KEY' not in os.environ")
+def test_multistep_converter():
+    conv = VideoToTextConverter()
+    filename = join(get_test_data_path(), 'video', 'obama_speech.mp4')
+    stim = VideoStim(filename)
+    text = conv.transform(stim)
+    assert isinstance(text, ComplexTextStim)
+    first_word = next(w for w in text)
+    assert type(first_word) == TextStim

--- a/featurex/tests/test_core.py
+++ b/featurex/tests/test_core.py
@@ -3,7 +3,8 @@ from featurex.stimuli.image import ImageStim
 from featurex.stimuli.text import TextStim
 from featurex.export import FSLExporter
 from featurex.lazy import extract
-from featurex.transformers import get_transformer, get_converter
+from featurex.transformers import get_transformer
+from featurex.converters import get_converter
 from featurex.extractors import Extractor, ExtractorResult
 from featurex.extractors.image import VibranceExtractor
 from featurex.extractors.audio import STFTAudioExtractor

--- a/featurex/tests/test_extractors.py
+++ b/featurex/tests/test_extractors.py
@@ -70,6 +70,17 @@ def test_implicit_stim_conversion2():
     assert first_word['text_length'][0] > 0
 
 
+@pytest.mark.skipif("'WIT_AI_API_KEY' not in os.environ")
+def test_implicit_stim_conversion3():
+    audio_dir = join(get_test_data_path(), 'video')
+    stim = VideoStim(join(audio_dir, 'obama_speech.mp4'))
+    ext = LengthExtractor()
+    result = ext.extract(stim)
+    first_word = result[0].to_df()
+    assert 'text_length' in first_word.columns
+    # Right now it's using via visual Text, need to add tests for via Audio
+
+
 def test_text_extractor():
     stim = ComplexTextStim(join(TEXT_DIR, 'sample_text.txt'),
                            columns='to', default_duration=1)

--- a/featurex/tests/test_extractors.py
+++ b/featurex/tests/test_extractors.py
@@ -77,8 +77,9 @@ def test_implicit_stim_conversion3():
     ext = LengthExtractor()
     result = ext.extract(stim)
     first_word = result[0].to_df()
+    # The word should be "today"
     assert 'text_length' in first_word.columns
-    # Right now it's using via visual Text, need to add tests for via Audio
+    assert first_word['text_length'][0] == 5
 
 
 def test_text_extractor():

--- a/featurex/transformers.py
+++ b/featurex/transformers.py
@@ -30,6 +30,7 @@ class Transformer(with_metaclass(ABCMeta)):
                 return self._transform(self._validate(stims), *args, **kwargs)
 
     def _validate(self, stim):
+        from featurex.converters import get_converter
         if not isinstance(stim, self._input_type):
             converter = get_converter(type(stim), self._input_type)
             if converter:
@@ -62,42 +63,6 @@ class BatchTransformerMixin():
     def transform(self, stims, *args, **kwargs):
         return self._transform(self._validate(stims), *args, **kwargs)
 
-
-def get_converter(in_type, out_type):
-    ''' Scans the list of available Converters and returns an instantiation
-    of the first one whose input and output types match those passed in.
-    Args:
-        in_type (type): The type of input the converter must have.
-        out_type (type): The type of output the converter must have.
-    '''
-
-    # Recursively get all classes that inherit from the passed base class
-    def get_subclasses(cls):
-        subclasses = []
-        for sc in cls.__subclasses__():
-            subclasses.append(sc)
-            subclasses.extend(get_subclasses(sc))
-        return subclasses
-
-    from featurex.converters import Converter
-    base = Converter
-
-    bm = base.__module__
-    submods = importlib.import_module(bm).__all__
-    sources = ['%s.%s' % (bm, sm) for sm in submods]
-    [importlib.import_module(s) for s in sources]
-
-    transformers = get_subclasses(base)
-    for a in transformers:
-        concrete = len(a.__abstractmethods__) == 0
-        if a._input_type == in_type and a._output_type == out_type and concrete:
-            try:
-                conv = a()
-                return conv
-            except ValueError:
-                # Important for API converters
-                pass
-    return None
 
 def get_transformer(name, base=None, *args, **kwargs):
     ''' Scans list of currently available Transformer classes and returns an


### PR DESCRIPTION
First go at addressing #83.
-Moved `get_converter` to the `Converters` module
-Implemented a `MultistepConverter` structure for easily specifying conversion paths
-Implemented and tested a `VideoToTextConverter` going via audio

Future work:
-Additional testing
-Implementing other `MultistepConverter`s
-Read in default `_via` properties through a config file

Creating the `MultistepConverter` object seemed pretty convenient, but I didn't ponder much on its extensibility. Open to going other directions, this was just a first pass.