### PR TITLE
Converter improvements

### DIFF
--- a/pliers/converters/__init__.py
+++ b/pliers/converters/__init__.py
@@ -9,7 +9,7 @@ import importlib
 cachedir = mkdtemp()
 memory = Memory(cachedir=cachedir, verbose=0)
 
-__all__ = ['api', 'audio', 'google', 'image', 'video']
+__all__ = ['api', 'audio', 'google', 'image', 'video', 'multistep']
 
 
 class Converter(with_metaclass(ABCMeta, Transformer)):
@@ -43,27 +43,6 @@ class Converter(with_metaclass(ABCMeta, Transformer)):
 
     def _transform(self, stim, *args, **kwargs):
         return self.convert(stim, *args, **kwargs)
-
-
-class MultistepConverter(Converter):
-    ''' Base class for Converters doing more than one step.
-    Args:
-        via (list): Ordered sequence of types to convert through
-    '''
-
-    def __init__(self, via=None):
-        super(MultistepConverter, self).__init__()
-        self.via = self._via if via is None else via
-
-    def _convert(self, stim):
-        for i, step in enumerate(self.via):
-            converter = get_converter(type(stim), step)
-            if converter:
-                stim = converter.transform(stim)
-            else:
-                msg = "Conversion failed during step %d" % i
-                raise ValueError(msg)
-        return stim
 
 
 def get_converter(in_type, out_type):

--- a/pliers/converters/__init__.py
+++ b/pliers/converters/__init__.py
@@ -45,6 +45,27 @@ class Converter(with_metaclass(ABCMeta, Transformer)):
         return self.convert(stim, *args, **kwargs)
 
 
+class MultistepConverter(Converter):
+    ''' Base class for Converters doing more than one step.
+    Args:
+        via (list): Ordered sequence of types to convert through
+    '''
+
+    def __init__(self, via=None):
+        super(MultistepConverter, self).__init__()
+        self.via = self._via if via is None else via
+
+    def _convert(self, stim):
+        for i, step in enumerate(self.via):
+            converter = get_converter(type(stim), step)
+            if converter:
+                stim = converter.transform(stim)
+            else:
+                msg = "Conversion failed during step %d" % i
+                raise ValueError(msg)
+        return stim
+
+
 def get_converter(in_type, out_type):
     ''' Scans the list of available Converters and returns an instantiation
     of the first one whose input and output types match those passed in.

--- a/pliers/converters/multistep.py
+++ b/pliers/converters/multistep.py
@@ -1,0 +1,42 @@
+from pliers.converters import Converter
+from pliers.converters import get_converter
+from pliers.stimuli import Stim
+from pliers.stimuli.audio import AudioStim
+from pliers.stimuli.video import VideoStim
+from pliers.stimuli.text import TextStim
+
+
+class MultiStepConverter(Converter):
+    ''' Base class for Converters doing more than one step.
+    Args:
+        steps (list): Ordered list describing the sequence of desired
+            conversions. Each element in the list can be either a Converter or
+            a Stim class. If the former, the exact Converter provided is used
+            as the step. If a Stim subclass is passed (e.g., AudioStim), then
+            the first matching Converter class will be used.
+    '''
+
+    def __init__(self, steps=None):
+        super(MultiStepConverter, self).__init__()
+        self.steps = self._steps if steps is None else steps
+
+    def _convert(self, stim):
+        for i, step in enumerate(self.steps):
+            if issubclass(step, Stim):
+                converter = get_converter(type(stim), step)
+                if converter is None:
+                    msg = "Conversion failed at step %d; unable to find a " + \
+                            "Converter capable of transforming a %s into a %s." \
+                            % (i, stim.__class__.__name__, step.__name__)
+                    raise ValueError(msg)
+            else:
+                converter = step
+            stim = converter.transform(stim)                    
+        return stim
+
+
+class VideoToTextConverter(MultiStepConverter):
+
+    _input_type = VideoStim
+    _output_type = TextStim
+    _steps = [AudioStim, TextStim]

--- a/pliers/converters/video.py
+++ b/pliers/converters/video.py
@@ -2,7 +2,7 @@ from pliers.stimuli.video import VideoStim, DerivedVideoStim, VideoFrameStim
 from pliers.stimuli.audio import AudioStim
 from pliers.converters import Converter
 from pliers.stimuli.text import TextStim
-from pliers.converters import Converter, MultistepConverter
+from pliers.converters import Converter
 
 import pandas as pd
 import os
@@ -31,12 +31,6 @@ class VideoToAudioConverter(Converter):
                                         self.buffersize, self.bitrate,
                                         self.ffmpeg_params)
         return AudioStim(filename)
-
-
-class VideoToTextConverter(MultistepConverter):
-    _input_type = VideoStim
-    _output_type = TextStim
-    _via = [AudioStim, TextStim]
 
 
 class VideoToDerivedVideoConverter(Converter):

--- a/pliers/converters/video.py
+++ b/pliers/converters/video.py
@@ -1,6 +1,8 @@
 from pliers.stimuli.video import VideoStim, DerivedVideoStim, VideoFrameStim
 from pliers.stimuli.audio import AudioStim
 from pliers.converters import Converter
+from pliers.stimuli.text import TextStim
+from pliers.converters import Converter, MultistepConverter
 
 import pandas as pd
 import os
@@ -29,6 +31,12 @@ class VideoToAudioConverter(Converter):
                                         self.buffersize, self.bitrate,
                                         self.ffmpeg_params)
         return AudioStim(filename)
+
+
+class VideoToTextConverter(MultistepConverter):
+    _input_type = VideoStim
+    _output_type = TextStim
+    _via = [AudioStim, TextStim]
 
 
 class VideoToDerivedVideoConverter(Converter):

--- a/pliers/tests/test_converters.py
+++ b/pliers/tests/test_converters.py
@@ -2,8 +2,8 @@ from os.path import join, splitext
 from .utils import get_test_data_path
 from pliers.converters import memory, get_converter
 from pliers.converters.video import (FrameSamplingConverter, 
-                                        VideoToAudioConverter, 
-                                        VideoToTextConverter)
+                                        VideoToAudioConverter)
+from pliers.converters.multistep import VideoToTextConverter
 from pliers.converters.image import TesseractConverter, ImageToTextConverter
 from pliers.converters.api import (WitTranscriptionConverter, 
                                         GoogleSpeechAPIConverter,

--- a/pliers/tests/test_converters.py
+++ b/pliers/tests/test_converters.py
@@ -1,7 +1,9 @@
 from os.path import join, splitext
 from .utils import get_test_data_path
 from pliers.converters import memory, get_converter
-from pliers.converters.video import FrameSamplingConverter, VideoToAudioConverter
+from pliers.converters.video import (FrameSamplingConverter, 
+                                        VideoToAudioConverter, 
+                                        VideoToTextConverter)
 from pliers.converters.image import TesseractConverter, ImageToTextConverter
 from pliers.converters.api import (WitTranscriptionConverter, 
                                         GoogleSpeechAPIConverter,
@@ -172,3 +174,14 @@ def test_converter_memoization():
 
     # After clearing the cache, checks should fail
     assert convert_time <= cache_time * 2
+
+
+@pytest.mark.skipif("'WIT_AI_API_KEY' not in os.environ")
+def test_multistep_converter():
+    conv = VideoToTextConverter()
+    filename = join(get_test_data_path(), 'video', 'obama_speech.mp4')
+    stim = VideoStim(filename)
+    text = conv.transform(stim)
+    assert isinstance(text, ComplexTextStim)
+    first_word = next(w for w in text)
+    assert type(first_word) == TextStim

--- a/pliers/tests/test_extractors.py
+++ b/pliers/tests/test_extractors.py
@@ -70,6 +70,18 @@ def test_implicit_stim_conversion2():
     assert first_word['text_length'][0] > 0
 
 
+@pytest.mark.skipif("'WIT_AI_API_KEY' not in os.environ")
+def test_implicit_stim_conversion3():
+    audio_dir = join(get_test_data_path(), 'video')
+    stim = VideoStim(join(audio_dir, 'obama_speech.mp4'))
+    ext = LengthExtractor()
+    result = ext.extract(stim)
+    first_word = result[0].to_df()
+    # The word should be "today"
+    assert 'text_length' in first_word.columns
+    assert first_word['text_length'][0] == 5
+
+
 def test_text_extractor():
     stim = ComplexTextStim(join(TEXT_DIR, 'sample_text.txt'),
                            columns='to', default_duration=1)

--- a/pliers/transformers.py
+++ b/pliers/transformers.py
@@ -19,7 +19,12 @@ class Transformer(with_metaclass(ABCMeta)):
         # Iterate over the collection of stims contained in the input stim
         elif isinstance(stims, CollectionStimMixin) and \
            not issubclass(self._input_type, CollectionStimMixin):
-            return self._iterate(list(s for s in stims))
+            from pliers.converters import get_converter
+            converter = get_converter(type(stims), self._input_type)
+            if converter:
+                return self.transform(converter.transform(stims))
+            else:
+                return self._iterate(list(s for s in stims))
         # Pass the stim directly to the Transformer
         else:
             validated_stim = self._validate(stims)


### PR DESCRIPTION
This re-applies all the changes in #96 (sorry @qmac--I forgot about this PR until after I merged the name change PR, and it was much easier to manually apply your edits than to resolve the million merge conflicts it introduced), and some minor improvements (creates a new `multistep` module under `converters`, and allows passing of both `Converter`s and `Stim`s as `steps`).