### PR TITLE
enable passing strings to Transformers

### DIFF
--- a/pliers/stimuli/base.py
+++ b/pliers/stimuli/base.py
@@ -7,6 +7,7 @@ from collections import namedtuple
 from pliers import config
 import pandas as pd
 from types import GeneratorType
+import magic
 
 
 class Stim(with_metaclass(ABCMeta)):
@@ -67,7 +68,6 @@ def load_stims(source, dtype=None):
             one of 'video', 'image', 'audio', or 'text'.
     Returns: A list of Stims.
     """
-    import magic
     from .video import VideoStim, ImageStim
     from .audio import AudioStim
     from .text import TextStim

--- a/pliers/tests/test_transformers.py
+++ b/pliers/tests/test_transformers.py
@@ -1,9 +1,10 @@
 from pliers.transformers import get_transformer
-from pliers.extractors import Extractor, STFTAudioExtractor
+from pliers.extractors import Extractor, STFTAudioExtractor, BrightnessExtractor
 from pliers.stimuli.base import TransformationLog
 from pliers.stimuli import ImageStim
 from os.path import join
 from .utils import get_test_data_path, DummyExtractor
+import numpy as np
 
 
 def test_get_transformer_by_name():
@@ -25,3 +26,9 @@ def test_transformation_history():
     assert df.iloc[0]['transformer_class'] == 'DummyExtractor'
     assert eval(df.iloc[0]['transformer_params'])['param_A'] == 'giraffe'
     assert str(res) == 'ImageStim->DummyExtractor/ExtractorResult'
+
+def test_transform_with_string_input():
+
+    ext = BrightnessExtractor()
+    res = ext.extract(join(get_test_data_path(), 'image', 'apple.jpg'))
+    np.testing.assert_almost_equal(res[0].to_df()['brightness'].values[0], 0.887842942)

--- a/pliers/transformers.py
+++ b/pliers/transformers.py
@@ -1,10 +1,11 @@
-from pliers.stimuli.base import Stim, CollectionStimMixin, _log_transformation
+from pliers.stimuli.base import (Stim, CollectionStimMixin,
+                                 _log_transformation, load_stims)
 from pliers.stimuli.compound import CompoundStim
 from pliers.utils import listify
 from pliers import config
 import pliers
 
-from six import with_metaclass
+from six import with_metaclass, string_types
 from abc import ABCMeta, abstractmethod, abstractproperty
 import importlib
 from copy import deepcopy
@@ -23,6 +24,9 @@ class Transformer(with_metaclass(ABCMeta)):
 
     def transform(self, stims, *args, **kwargs):
 
+        if isinstance(stims, string_types):
+            stims = load_stims(stims)
+
         # If stims is a CompoundStim and the Transformer is expecting a single
         # input type, extract all matching stims
         if isinstance(stims, CompoundStim) and not isinstance(self._input_type, tuple):
@@ -33,7 +37,7 @@ class Transformer(with_metaclass(ABCMeta)):
 
         # If stims is an iterable, naively loop over elements.
         if isinstance(stims, (list, tuple, GeneratorType)):
-            return self._iterate(list(stims), *args, **kwargs)
+            return self._iterate(stims, *args, **kwargs)
 
         # Validate stim, and then either pass it directly to the Transformer
         # or, if a conversion occurred, recurse.


### PR DESCRIPTION
This is a small but useful tweak that allows passing of filenames directly to `Transformers`. I.e., in addition to this:

```python
img = ImageStim('my_image.jpg')
ext = MyExtractor()
result = ext.extract(img)
```

...a user can now do this:
```python
ext = MyExtractor()
result = ext.extract('my_image.jpg')
```

This leverages the `stimulus.load_stims` function, which already does intelligent loading of `Stim`s from filename strings based on the MIME type (via python-magic).