### PR TITLE
removed convert() and extract(); only transform() remains

### DIFF
--- a/examples/Graph.ipynb
+++ b/examples/Graph.ipynb
@@ -64,7 +64,7 @@
    "source": [
     "# Extract the audio\n",
     "conv = VideoToAudioConverter()\n",
-    "audio = conv.convert(video)"
+    "audio = conv.transform(video)"
    ]
   },
   {
@@ -77,7 +77,7 @@
    "source": [
     "# Subsample the video\n",
     "conv = FrameSamplingConverter(every=15)\n",
-    "derived = conv.convert(video)"
+    "derived = conv.transform(video)"
    ]
   },
   {
@@ -92,7 +92,7 @@
     "conv = TesseractConverter()\n",
     "visual_texts = []\n",
     "for frame in derived:\n",
-    "    visual_texts.append(conv.convert(frame))"
+    "    visual_texts.append(conv.transform(frame))"
    ]
   },
   {
@@ -105,7 +105,7 @@
    "source": [
     "# Extract text from the audio\n",
     "conv = WitTranscriptionConverter()\n",
-    "audio_text = conv.convert(audio)"
+    "audio_text = conv.transform(audio)"
    ]
   },
   {
@@ -120,7 +120,7 @@
     "ext = VibranceExtractor()\n",
     "visual_features = []\n",
     "for frame in derived:\n",
-    "    visual_features.append(ext.extract(frame))"
+    "    visual_features.append(ext.transform(frame))"
    ]
   },
   {
@@ -133,8 +133,8 @@
    "source": [
     "# Extract word length from both audio and visual text\n",
     "ext = LengthExtractor()\n",
-    "visual_length = [ext.extract(t) for t in visual_texts]\n",
-    "audio_length = [ext.extract(t) for t in audio_text]"
+    "visual_length = [ext.transform(t) for t in visual_texts]\n",
+    "audio_length = [ext.transform(t) for t in audio_text]"
    ]
   },
   {
@@ -550,7 +550,7 @@
     "graph = Graph()\n",
     "graph.add_children(visual_nodes)\n",
     "graph.add_children(audio_nodes)\n",
-    "graph.extract(video)"
+    "graph.transform(video)"
    ]
   },
   {

--- a/examples/VisionAPIs.ipynb
+++ b/examples/VisionAPIs.ipynb
@@ -41,7 +41,7 @@
    "source": [
     "# Configure and run extractor\n",
     "ext = ClarifaiAPIExtractor(select_classes=['animal','equipment', 'person', 'apple'])\n",
-    "results = [ext.extract(s) for s in stims]"
+    "results = [ext.transform(s) for s in stims]"
    ]
   },
   {

--- a/pliers/converters/base.py
+++ b/pliers/converters/base.py
@@ -16,9 +16,6 @@ class Converter(with_metaclass(ABCMeta, Transformer)):
         if config.cache_converters:
             self.transform = memory.cache(self.transform)
 
-    def convert(self, stim, *args, **kwargs):
-        return self.transform(stim, *args, **kwargs)
-
     @abstractmethod
     def _convert(self, stim):
         pass

--- a/pliers/extractors/base.py
+++ b/pliers/extractors/base.py
@@ -17,9 +17,6 @@ class Extractor(with_metaclass(ABCMeta, Transformer)):
         if config.cache_extractors:
             self.transform = memory.cache(self.transform)
 
-    def extract(self, stim, *args, **kwargs):
-        return self.transform(stim, *args, **kwargs)
-
     def transform(self, stim, *args, **kwargs):
         result = super(Extractor, self).transform(stim, *args, **kwargs)
         return list(result) if isinstance(result, GeneratorType) else result

--- a/pliers/filters/base.py
+++ b/pliers/filters/base.py
@@ -13,7 +13,7 @@ class Filter(with_metaclass(ABCMeta, Transformer)):
         if config.cache_filters:
             self.transform = memory.cache(self.transform)
 
-    def filter(self, stim, *args, **kwargs):
+    def transform(self, stim, *args, **kwargs):
         new_stim = self._filter(stim, *args, **kwargs)
         if not isinstance(new_stim, stim.__class__):
             raise ValueError("Filter must return a Stim of the same type as "

--- a/pliers/tests/test_converters.py
+++ b/pliers/tests/test_converters.py
@@ -21,7 +21,7 @@ def test_video_to_audio_converter():
     filename = join(get_test_data_path(), 'video', 'small.mp4')
     video = VideoStim(filename)
     conv = VideoToAudioConverter()
-    audio = conv.convert(video)
+    audio = conv.transform(video)
     assert audio.name == 'small.mp4->small.wav'
     assert audio.history.source_class == 'VideoStim'
     assert audio.history.source_file == filename
@@ -149,7 +149,7 @@ def test_converter_memoization():
 
     def convert(stim):
         start_time = time.time()
-        stim = conv.convert(stim)
+        stim = conv.transform(stim)
         return time.time() - start_time
 
     # Time taken first time through
@@ -192,10 +192,10 @@ def test_stim_history_tracking():
     video = VideoStim(join(get_test_data_path(), 'video', 'obama_speech.mp4'))
     assert video.history is None
     conv = VideoToAudioConverter()
-    stim = conv.convert(video)
+    stim = conv.transform(video)
     assert str(stim.history) == 'VideoStim->VideoToAudioConverter/AudioStim'
     conv = WitTranscriptionConverter()
-    stim = conv.convert(stim)
+    stim = conv.transform(stim)
     assert str(stim.history) == 'VideoStim->VideoToAudioConverter/AudioStim->WitTranscriptionConverter/ComplexTextStim'
 
 

--- a/pliers/tests/test_extractors.py
+++ b/pliers/tests/test_extractors.py
@@ -38,7 +38,7 @@ def test_implicit_stim_iteration():
     stim1 = ImageStim(join(image_dir, 'apple.jpg'))
     stim2 = ImageStim(join(image_dir, 'obama.jpg'))
     de = DummyExtractor()
-    results = de.extract([stim1, stim2])
+    results = de.transform([stim1, stim2])
     assert len(results) == 2
     assert isinstance(results[0], ExtractorResult)
 
@@ -47,7 +47,7 @@ def test_implicit_stim_conversion():
     image_dir = join(get_test_data_path(), 'image')
     stim = ImageStim(join(image_dir, 'button.jpg'))
     ext = LengthExtractor()
-    result = ext.extract(stim).to_df()
+    result = ext.transform(stim).to_df()
     assert 'text_length' in result.columns
     assert result['text_length'][0] == 4
 
@@ -57,7 +57,7 @@ def test_implicit_stim_conversion2():
     audio_dir = join(get_test_data_path(), 'audio')
     stim = AudioStim(join(audio_dir, 'homer.wav'))
     ext = LengthExtractor()
-    result = ext.extract(stim)
+    result = ext.transform(stim)
     first_word = result[0].to_df()
     assert 'text_length' in first_word.columns
     assert first_word['text_length'][0] > 0
@@ -68,7 +68,7 @@ def test_implicit_stim_conversion3():
     video_dir = join(get_test_data_path(), 'video')
     stim = VideoStim(join(video_dir, 'obama_speech.mp4'))
     ext = LengthExtractor()
-    result = ext.extract(stim)
+    result = ext.transform(stim)
     first_word = result[0].to_df()
     # The word should be "today"
     assert 'text_length' in first_word.columns
@@ -81,7 +81,7 @@ def test_text_extractor():
     td = DictionaryExtractor(join(TEXT_DIR, 'test_lexical_dictionary.txt'),
                              variables=['length', 'frequency'])
     assert td.data.shape == (7, 2)
-    result = td.extract(stim)[2].to_df()
+    result = td.transform(stim)[2].to_df()
     assert np.isnan(result.iloc[0, 1])
     assert result.shape == (1, 4)
     assert np.isclose(result['frequency'][0], 11.729, 1e-5)
@@ -90,7 +90,7 @@ def test_text_extractor():
 def test_text_length_extractor():
     stim = TextStim(text='hello world')
     ext = LengthExtractor()
-    result = ext.extract(stim).to_df()
+    result = ext.transform(stim).to_df()
     assert 'text_length' in result.columns
     assert result['text_length'][0] == 11
 
@@ -98,7 +98,7 @@ def test_text_length_extractor():
 def test_unique_words_extractor():
     stim = TextStim(text='hello hello world')
     ext = NumUniqueWordsExtractor()
-    result = ext.extract(stim).to_df()
+    result = ext.transform(stim).to_df()
     assert 'num_unique_words' in result.columns
     assert result['num_unique_words'][0] == 2
 
@@ -109,13 +109,13 @@ def test_dictionary_extractor():
     assert td.data.shape == (7, 2)
 
     stim = TextStim(text='annotation')
-    result = td.extract(stim).to_df()
+    result = td.transform(stim).to_df()
     assert np.isnan(result['onset'][0])
     assert 'length' in result.columns
     assert result['length'][0] == 10
 
     stim2 = TextStim(text='some')
-    result = td.extract(stim2).to_df()
+    result = td.transform(stim2).to_df()
     assert np.isnan(result['onset'][0])
     assert 'frequency' in result.columns
     assert np.isnan(result['frequency'][0])
@@ -124,7 +124,7 @@ def test_dictionary_extractor():
 def test_predefined_dictionary_extractor():
     stim = TextStim(text='enormous')
     td = PredefinedDictionaryExtractor(['aoa/Freq_pm'])
-    result = td.extract(stim).to_df()
+    result = td.transform(stim).to_df()
     assert result.shape == (1, 3)
     assert 'aoa_Freq_pm' in result.columns
     assert np.isclose(result['aoa_Freq_pm'][0], 10.313725, 1e-5)
@@ -135,7 +135,7 @@ def test_stft_extractor():
     stim = AudioStim(join(audio_dir, 'barber.wav'))
     ext = STFTAudioExtractor(frame_size=1., spectrogram=False,
                         freq_bins=[(100, 300), (300, 3000), (3000, 20000)])
-    result = ext.extract(stim)
+    result = ext.transform(stim)
     df = result.to_df()
     assert df.shape == (557, 5)
 
@@ -146,14 +146,14 @@ def test_mean_amplitude_extractor():
     text = ComplexTextStim(text_file)
     stim = TranscribedAudioCompoundStim(audio=audio, text=text)
     ext = MeanAmplitudeExtractor()
-    result = ext.extract(stim).to_df()
+    result = ext.transform(stim).to_df()
     targets = [-0.154661, 0.121521]
     assert np.allclose(result['mean_amplitude'], targets)
 
 
 def test_part_of_speech_extractor():
     stim = ComplexTextStim(join(TEXT_DIR, 'complex_stim_with_header.txt'))
-    result = PartOfSpeechExtractor().extract(stim).to_df()
+    result = PartOfSpeechExtractor().transform(stim).to_df()
     assert result.shape == (4, 6)
     assert 'NN' in result.columns
     assert result['NN'].sum() == 1
@@ -163,7 +163,7 @@ def test_part_of_speech_extractor():
 def test_brightness_extractor():
     image_dir = join(get_test_data_path(), 'image')
     stim = ImageStim(join(image_dir, 'apple.jpg'))
-    result = BrightnessExtractor().extract(stim).to_df()
+    result = BrightnessExtractor().transform(stim).to_df()
     brightness = result['brightness'][0]
     assert np.isclose(brightness, 0.88784294, 1e-5)
 
@@ -172,7 +172,7 @@ def test_sharpness_extractor():
     pytest.importorskip('cv2')
     image_dir = join(get_test_data_path(), 'image')
     stim = ImageStim(join(image_dir, 'apple.jpg'))
-    result = SharpnessExtractor().extract(stim).to_df()
+    result = SharpnessExtractor().transform(stim).to_df()
     sharpness = result['sharpness'][0]
     assert np.isclose(sharpness, 1.0, 1e-5)
 
@@ -180,7 +180,7 @@ def test_sharpness_extractor():
 def test_vibrance_extractor():
     image_dir = join(get_test_data_path(), 'image')
     stim = ImageStim(join(image_dir, 'apple.jpg'))
-    result = VibranceExtractor().extract(stim).to_df()
+    result = VibranceExtractor().transform(stim).to_df()
     color = result['vibrance'][0]
     assert np.isclose(color, 1370.65482988, 1e-5)
 
@@ -189,7 +189,7 @@ def test_saliency_extractor():
     pytest.importorskip('cv2')
     image_dir = join(get_test_data_path(), 'image')
     stim = ImageStim(join(image_dir, 'apple.jpg'))
-    result = SaliencyExtractor().extract(stim).to_df()
+    result = SaliencyExtractor().transform(stim).to_df()
     ms = result['max_saliency'][0]
     assert np.isclose(ms, 0.99669953, 1e-5)
     sf = result['frac_high_saliency'][0]
@@ -200,7 +200,7 @@ def test_optical_flow_extractor():
     pytest.importorskip('cv2')
     video_dir = join(get_test_data_path(), 'video')
     stim = VideoStim(join(video_dir, 'small.mp4'))
-    result = DenseOpticalFlowExtractor().extract(stim).to_df()
+    result = DenseOpticalFlowExtractor().transform(stim).to_df()
     target = result.query('onset==3.0')['total_flow']
     assert np.isclose(target, 86248.05, 1e-5)
 
@@ -211,7 +211,7 @@ def test_indicoAPI_extractor():
     srt_stim = ComplexTextStim(srtfile)
     ext = IndicoAPIExtractor(
         api_key=os.environ['INDICO_APP_KEY'], models=['emotion', 'personality'])
-    result = ext.extract(srt_stim).to_df()
+    result = ext.transform(srt_stim).to_df()
     outdfKeysCheck = set([
         'onset',
         'duration',
@@ -231,7 +231,7 @@ def test_indicoAPI_extractor():
 def test_clarifaiAPI_extractor():
     image_dir = join(get_test_data_path(), 'image')
     stim = ImageStim(join(image_dir, 'apple.jpg'))
-    result = ClarifaiAPIExtractor().extract(stim).to_df()
+    result = ClarifaiAPIExtractor().transform(stim).to_df()
     assert result['apple'][0] > 0.5
     assert result.ix[:,5][0] > 0.0
 
@@ -243,12 +243,12 @@ def test_merge_extractor_results_by_features():
 
     # Merge results for static Stims (no onsets)
     extractors = [BrightnessExtractor(), VibranceExtractor()]
-    results = [e.extract(stim) for e in extractors]
+    results = [e.transform(stim) for e in extractors]
     df = ExtractorResult.merge_features(results)
 
     de = DummyExtractor()
     de_names = ['Extractor1', 'Extractor2', 'Extractor3']
-    results = [de.extract(stim, name) for name in de_names]
+    results = [de.transform(stim, name) for name in de_names]
     df = ExtractorResult.merge_features(results)
     assert df.shape == (177, 13)
     assert df.columns.levels[1].unique().tolist() == ['duration', 0, 1, 2, '']
@@ -261,7 +261,7 @@ def test_merge_extractor_results_by_stims():
     stim1 = ImageStim(join(image_dir, 'apple.jpg'))
     stim2 = ImageStim(join(image_dir, 'obama.jpg'))
     de = DummyExtractor()
-    results = [de.extract(stim1), de.extract(stim2)]
+    results = [de.transform(stim1), de.transform(stim2)]
     df = ExtractorResult.merge_stims(results)
     assert df.shape == (200, 5)
     assert df.columns.tolist() == ['onset', 'duration', 0, 1, 2]
@@ -275,8 +275,8 @@ def test_merge_extractor_results():
     stim2 = ImageStim(join(image_dir, 'obama.jpg'))
     de = DummyExtractor()
     de_names = ['Extractor1', 'Extractor2', 'Extractor3']
-    results = [de.extract(stim1, name) for name in de_names]
-    results += [de.extract(stim2, name) for name in de_names]
+    results = [de.transform(stim1, name) for name in de_names]
+    results += [de.transform(stim2, name) for name in de_names]
     df = merge_results(results)
     assert df.shape == (355, 13)
     cols = ['onset', 'class', 'filename', 'history', 'stim']

--- a/pliers/tests/test_google_extractors.py
+++ b/pliers/tests/test_google_extractors.py
@@ -41,7 +41,7 @@ def test_google_vision_api_face_extractor():
     ext = GoogleVisionAPIFaceExtractor(num_retries=5)
     filename = join(get_test_data_path(), 'image', 'obama.jpg')
     stim = ImageStim(filename)
-    result = ext.extract(stim).to_df()
+    result = ext.transform(stim).to_df()
     assert 'joyLikelihood' in result.columns
     assert result['joyLikelihood'][0] == 'VERY_LIKELY'
     assert result['face_detectionConfidence'][0] > 0.7
@@ -53,11 +53,11 @@ def test_google_vision_multiple_face_extraction():
     stim = ImageStim(filename)
     # Only first record
     ext = GoogleVisionAPIFaceExtractor(handle_annotations='first')
-    result1 = ext.extract(stim).to_df()
+    result1 = ext.transform(stim).to_df()
     assert 'joyLikelihood' in result1.columns
     # All records
     ext = GoogleVisionAPIFaceExtractor(handle_annotations='prefix')
-    result2 = ext.extract(stim).to_df()
+    result2 = ext.transform(stim).to_df()
     assert 'face2_joyLikelihood' in result2.columns
     assert result2.shape[1] > result1.shape[1]
 
@@ -67,7 +67,7 @@ def test_google_vision_api_label_extractor():
     ext = GoogleVisionAPILabelExtractor(num_retries=5)
     filename = join(get_test_data_path(), 'image', 'apple.jpg')
     stim = ImageStim(filename)
-    result = ext.extract(stim).to_df()
+    result = ext.transform(stim).to_df()
     assert 'apple' in result.columns
     assert result['apple'][0] > 0.75
 
@@ -77,7 +77,7 @@ def test_google_vision_api_properties_extractor():
     ext = GoogleVisionAPIPropertyExtractor(num_retries=5)
     filename = join(get_test_data_path(), 'image', 'apple.jpg')
     stim = ImageStim(filename)
-    result = ext.extract(stim).to_df()
+    result = ext.transform(stim).to_df()
     assert (158, 13, 29) in result.columns
     assert np.isfinite(result[(158, 13, 29)][0])
 

--- a/pliers/tests/test_io.py
+++ b/pliers/tests/test_io.py
@@ -23,7 +23,7 @@ def test_convert_to_long():
     stim = AudioStim(join(audio_dir, 'barber.wav'))
     ext = STFTAudioExtractor(frame_size=1., spectrogram=False,
                         freq_bins=[(100, 300), (300, 3000), (3000, 20000)])
-    timeline = ext.extract(stim)
+    timeline = ext.transform(stim)
     long_timeline = to_long_format(timeline)
     assert long_timeline.shape == (timeline.to_df().shape[0] * 3, 4)
     assert 'feature' in long_timeline.columns

--- a/pliers/tests/test_stims.py
+++ b/pliers/tests/test_stims.py
@@ -161,7 +161,7 @@ def test_transformations_on_compound_stim():
     stim = CompoundStim([image1, image2, text])
 
     ext = BrightnessExtractor()
-    results = ext.extract(stim)
+    results = ext.transform(stim)
     assert len(results) == 2
     assert np.allclose(results[0].data[0], 0.88784294)
 

--- a/pliers/tests/test_transformers.py
+++ b/pliers/tests/test_transformers.py
@@ -15,7 +15,7 @@ def test_transformation_history():
 
     img = ImageStim(join(get_test_data_path(), 'image', 'apple.jpg'))
     ext = DummyExtractor('giraffe')
-    res = ext.extract(img).history
+    res = ext.transform(img).history
     assert isinstance(res, TransformationLog)
     df = res.to_df()
     assert df.shape == (1, 8)


### PR DESCRIPTION
On reflection, I decided it's a bad idea to have separate convert(), extract() and filter() methods that are all aliases for transform() and have no purpose other than signaling what kind of `Transformer` we're dealing with. From now on, all transformation calls should be made strictly with `.transform()`.