### PR TITLE
Various fixes

### DIFF
--- a/pliers/config.py
+++ b/pliers/config.py
@@ -3,3 +3,6 @@ cache_converters = False
 cache_filters = False
 cache_extractors = False
 log_transformations = True
+default_converters = {
+    'AudioStim->TextStim': ('IBMSpeechAPIConverter', 'WitTranscriptionConverter')
+}

--- a/pliers/converters/__init__.py
+++ b/pliers/converters/__init__.py
@@ -5,7 +5,7 @@ from .google import GoogleVisionAPITextConverter
 from .image import TesseractConverter
 from .iterators import (VideoFrameIterator, DerivedVideoFrameIterator,
                         ComplexTextIterator)
-from .multistep import VideoToTextConverter
+from .multistep import VideoToTextConverter, VideoToComplexTextConverter
 from .video import VideoToAudioConverter, FrameSamplingConverter
 
 __all__ = [
@@ -18,6 +18,7 @@ __all__ = [
     'DerivedVideoFrameIterator',
     'ComplexTextIterator',
     'VideoToTextConverter',
+    'VideoToComplexTextConverter',
     'VideoToAudioConverter',
     'FrameSamplingConverter',
     'Converter',

--- a/pliers/converters/api.py
+++ b/pliers/converters/api.py
@@ -25,6 +25,7 @@ class SpeechRecognitionAPIConverter(AudioToTextConverter, EnvironmentKeyMixin):
         pass
 
     def __init__(self, api_key=None):
+        super(SpeechRecognitionAPIConverter, self).__init__()
         import speech_recognition as sr
         if api_key is None:
             try:

--- a/pliers/converters/audio.py
+++ b/pliers/converters/audio.py
@@ -2,6 +2,7 @@ from pliers.stimuli.audio import AudioStim
 from pliers.stimuli.text import TextStim
 from .base import Converter
 
+
 class AudioToTextConverter(Converter):
 
     ''' Base AudioToText Converter class; all subclasses can only be applied to

--- a/pliers/converters/base.py
+++ b/pliers/converters/base.py
@@ -55,7 +55,8 @@ def get_converter(in_type, out_type, *args, **kwargs):
         if not issubclass(cls, Converter):
             continue
         concrete = len(cls.__abstractmethods__) == 0
-        if cls._input_type == in_type and cls._output_type == out_type and concrete:
+        if cls._input_type == in_type and cls._output_type == out_type and \
+            concrete and cls.available:
             try:
                 conv = cls(*args, **kwargs)
                 return conv

--- a/pliers/converters/base.py
+++ b/pliers/converters/base.py
@@ -50,17 +50,22 @@ def get_converter(in_type, out_type, *args, **kwargs):
     '''
     convs = pliers.converters.__all__
 
+    # If config includes default converters for this combination, try them first
+    conv_str = '%s->%s' % (in_type.__name__, out_type.__name__)
+    if conv_str in config.default_converters:
+        convs = list(config.default_converters[conv_str]) + convs
+
     for name in convs:
         cls = getattr(pliers.converters, name)
         if not issubclass(cls, Converter):
             continue
-        concrete = len(cls.__abstractmethods__) == 0
-        if cls._input_type == in_type and cls._output_type == out_type and \
-            concrete and cls.available:
+
+        if cls._input_type == in_type and cls._output_type == out_type and cls.available:
             try:
                 conv = cls(*args, **kwargs)
                 return conv
             except ValueError:
                 # Important for API converters
                 pass
+
     return None

--- a/pliers/converters/base.py
+++ b/pliers/converters/base.py
@@ -25,18 +25,7 @@ class Converter(with_metaclass(ABCMeta, Transformer)):
         pass
 
     def _transform(self, stim, *args, **kwargs):
-        new_stim = self._convert(stim, *args, **kwargs)
-        if isinstance(new_stim, (list, tuple, GeneratorType)):
-            return new_stim
-        if new_stim.name is None:
-            new_stim.name = stim.name
-        else:
-            new_stim.name = stim.name + '->' + new_stim.name
-        if isinstance(new_stim, CollectionStimMixin):
-            for s in new_stim:
-                if s.name is None:
-                    s.name = stim.name
-        return new_stim
+        return self._convert(stim, *args, **kwargs)
 
 
 def get_converter(in_type, out_type, *args, **kwargs):

--- a/pliers/converters/multistep.py
+++ b/pliers/converters/multistep.py
@@ -2,7 +2,7 @@ from .base import Converter, get_converter
 from pliers.stimuli.base import Stim
 from pliers.stimuli.audio import AudioStim
 from pliers.stimuli.video import VideoStim
-from pliers.stimuli.text import TextStim
+from pliers.stimuli.text import TextStim, ComplexTextStim
 
 
 class MultiStepConverter(Converter):
@@ -38,4 +38,11 @@ class VideoToTextConverter(MultiStepConverter):
 
     _input_type = VideoStim
     _output_type = TextStim
+    _steps = [AudioStim, TextStim]
+
+
+class VideoToComplexTextConverter(MultiStepConverter):
+
+    _input_type = VideoStim
+    _output_type = ComplexTextStim
     _steps = [AudioStim, TextStim]

--- a/pliers/converters/multistep.py
+++ b/pliers/converters/multistep.py
@@ -15,6 +15,8 @@ class MultiStepConverter(Converter):
             the first matching Converter class will be used.
     '''
 
+    _loggable = False
+
     def __init__(self, steps=None):
         super(MultiStepConverter, self).__init__()
         self.steps = self._steps if steps is None else steps

--- a/pliers/extractors/__init__.py
+++ b/pliers/extractors/__init__.py
@@ -11,7 +11,6 @@ from .text import (ComplexTextExtractor, DictionaryExtractor,
                    NumUniqueWordsExtractor, PartOfSpeechExtractor)
 from .video import (DenseOpticalFlowExtractor)
 
-# __all__ = ['api', 'audio', 'google', 'image', 'text', 'video']
 __all__ = [
     'ExtractorResult',
     'IndicoAPIExtractor',
@@ -24,7 +23,7 @@ __all__ = [
     'BrightnessExtractor',
     'SaliencyExtractor',
     'SharpnessExtractor',
-    'VibranceExtractor'
+    'VibranceExtractor',
     'ComplexTextExtractor',
     'DictionaryExtractor',
     'PredefinedDictionaryExtractor',

--- a/pliers/extractors/base.py
+++ b/pliers/extractors/base.py
@@ -52,7 +52,6 @@ class ExtractorResult(object):
         df.insert(0, 'onset', self.onsets)
         if stim_name:
             df['stim'] = self.stim.name
-            df.set_index('stim', append=True, inplace=True)
         return df
 
     @property

--- a/pliers/extractors/base.py
+++ b/pliers/extractors/base.py
@@ -114,16 +114,14 @@ class ExtractorResult(object):
         result.insert(0, 'history', str(results[0].history))
 
         if stim_names:
-            result['stim'] = list(stims)[0]
-            result.set_index('stim', append=True, inplace=True)
-            result = result.sort_index()
+            result.insert(0, 'stim', list(stims)[0])
 
-        return result.sort_values(['onset'])
+        return result.sort_values(['onset']).reset_index(drop=True)
 
     @classmethod
     def merge_stims(cls, results, stim_names=True):
         results = [r.to_df(True) if isinstance(r, ExtractorResult) else r for r in results]
-        return pd.concat(results, axis=0).sort_values('onset')
+        return pd.concat(results, axis=0).sort_values('onset').reset_index(drop=True)
 
 
 def merge_results(results, extractor_names=True, stim_names=True):
@@ -142,7 +140,7 @@ def merge_results(results, extractor_names=True, stim_names=True):
     stims = defaultdict(list)
 
     for r in results:
-        stims[r.stim.name].append(r)
+        stims[id(r.stim)].append(r)
 
     # First concatenate all features separately for each Stim
     for k, v in stims.items():

--- a/pliers/extractors/text.py
+++ b/pliers/extractors/text.py
@@ -34,8 +34,8 @@ class ComplexTextExtractor(Extractor):
 
     def _extract(self, stim):
         ''' Returns all words. '''
-        props = [(e.text, e.onset, e.duration) for e in self.elements]
-        vals, onsets, durations = zip(*props)
+        props = [(e.text, e.onset, e.duration) for e in stim.elements]
+        vals, onsets, durations = map(list, zip(*props))
         return ExtractorResult(vals, stim, self, ['word'], onsets, durations)
 
 

--- a/pliers/google.py
+++ b/pliers/google.py
@@ -2,7 +2,8 @@ import base64
 import os
 import tempfile
 from scipy.misc import imsave
-from pliers.transformers import Transformer, BatchTransformerMixin
+from pliers.transformers import (Transformer, BatchTransformerMixin,
+                                 EnvironmentKeyMixin)
 
 try:
     from googleapiclient import discovery, errors
@@ -15,7 +16,9 @@ DISCOVERY_URL = 'https://{api}.googleapis.com/$discovery/rest?version={apiVersio
 BATCH_SIZE = 10
 
 
-class GoogleAPITransformer(Transformer, BatchTransformerMixin):
+class GoogleAPITransformer(Transformer, BatchTransformerMixin, EnvironmentKeyMixin):
+
+    _env_keys = 'GOOGLE_APPLICATION_CREDENTIALS'
 
     def __init__(self, discovery_file=None, api_version='v1', max_results=100,
                  num_retries=3, handle_annotations='prefix'):

--- a/pliers/stimuli/base.py
+++ b/pliers/stimuli/base.py
@@ -7,7 +7,6 @@ from collections import namedtuple
 from pliers import config
 import pandas as pd
 from types import GeneratorType
-import magic
 
 
 class Stim(with_metaclass(ABCMeta)):
@@ -80,6 +79,7 @@ def load_stims(source, dtype=None):
     stims = []
 
     def load_file(source):
+        import magic  # requires libmagic, so import here
         mime = magic.from_file(source, mime=True)
         if not isinstance(mime, string_types):
             mime = mime.decode('utf-8')

--- a/pliers/stimuli/base.py
+++ b/pliers/stimuli/base.py
@@ -106,8 +106,8 @@ def load_stims(source, dtype=None):
 
 def _log_transformation(source, result, trans=None):
 
-    if not config.log_transformations:
-        return
+    if not config.log_transformations or (trans is not None and not trans._loggable):
+        return result
 
     if isinstance(result, (list, tuple, GeneratorType)):
         return (_log_transformation(source, r, trans) for r in result)

--- a/pliers/stimuli/video.py
+++ b/pliers/stimuli/video.py
@@ -19,8 +19,6 @@ class VideoFrameStim(ImageStim):
         super(VideoFrameStim, self).__init__(filename, onset, duration, data)
         if data is None:
             self.data = self.video.get_frame(index=frame_num).data
-        if video.filename:
-            self.name = video.name + '->'
         self.name += 'frame[%s]' % frame_num
 
 

--- a/pliers/tests/test_converters.py
+++ b/pliers/tests/test_converters.py
@@ -22,7 +22,7 @@ def test_video_to_audio_converter():
     video = VideoStim(filename)
     conv = VideoToAudioConverter()
     audio = conv.transform(video)
-    assert audio.name == 'small.mp4->small.wav'
+    assert audio.name == 'small.wav'
     assert audio.history.source_class == 'VideoStim'
     assert audio.history.source_file == filename
     assert splitext(video.filename)[0] == splitext(audio.filename)[0]
@@ -42,7 +42,7 @@ def test_derived_video_converter():
     assert len(derived.elements) == math.ceil(video.n_frames / 3.0)
     first = next(f for f in derived)
     assert type(first) == VideoFrameStim
-    assert first.name == 'small.mp4->frame[0]'
+    assert first.name == 'frame[0]'
     assert first.duration == 3 * (1 / 30.0)
 
     # Should refilter from original frames
@@ -113,7 +113,7 @@ def test_tesseract_converter():
     stim = ImageStim(join(image_dir, 'button.jpg'))
     conv = TesseractConverter()
     out_stim = conv.transform(stim)
-    assert out_stim.name == 'button.jpg->text[Exit]'
+    assert out_stim.name == 'text[Exit]'
     assert out_stim.history.source_class == 'ImageStim'
     assert out_stim.history.source_name == 'button.jpg'
 

--- a/pliers/tests/test_extractors.py
+++ b/pliers/tests/test_extractors.py
@@ -7,7 +7,8 @@ from pliers.extractors import (DictionaryExtractor, PartOfSpeechExtractor,
                                MeanAmplitudeExtractor, BrightnessExtractor,
                                SharpnessExtractor,VibranceExtractor,
                                SaliencyExtractor, DenseOpticalFlowExtractor,
-                               IndicoAPIExtractor, ClarifaiAPIExtractor)
+                               IndicoAPIExtractor, ClarifaiAPIExtractor,
+                               ComplexTextExtractor)
 from pliers.stimuli import (TextStim, ComplexTextStim, ImageStim, VideoStim,
                             AudioStim, TranscribedAudioCompoundStim)
 from pliers.support.download import download_nltk_data
@@ -250,7 +251,7 @@ def test_merge_extractor_results_by_features():
     de_names = ['Extractor1', 'Extractor2', 'Extractor3']
     results = [de.transform(stim, name) for name in de_names]
     df = ExtractorResult.merge_features(results)
-    assert df.shape == (177, 13)
+    assert df.shape == (177, 14)
     assert df.columns.levels[1].unique().tolist() == ['duration', 0, 1, 2, '']
     cols = cols = ['onset', 'class', 'filename', 'history', 'stim']
     assert df.columns.levels[0].unique().tolist() == de_names + cols
@@ -263,9 +264,9 @@ def test_merge_extractor_results_by_stims():
     de = DummyExtractor()
     results = [de.transform(stim1), de.transform(stim2)]
     df = ExtractorResult.merge_stims(results)
-    assert df.shape == (200, 5)
-    assert df.columns.tolist() == ['onset', 'duration', 0, 1, 2]
-    assert set(df.index.levels[1].unique()) == set(['obama.jpg', 'apple.jpg'])
+    assert df.shape == (200, 6)
+    assert set(df.columns.tolist()) == set(['onset', 'duration', 0, 1, 2, 'stim'])
+    assert set(df['stim'].unique()) == set(['obama.jpg', 'apple.jpg'])
 
 
 def test_merge_extractor_results():
@@ -278,8 +279,8 @@ def test_merge_extractor_results():
     results = [de.transform(stim1, name) for name in de_names]
     results += [de.transform(stim2, name) for name in de_names]
     df = merge_results(results)
-    assert df.shape == (355, 13)
+    assert df.shape == (355, 14)
     cols = ['onset', 'class', 'filename', 'history', 'stim']
     assert df.columns.levels[0].unique().tolist() == de_names + cols
     assert df.columns.levels[1].unique().tolist() == ['duration', 0, 1, 2, '']
-    assert set(df.index.levels[1].unique()) == set(['obama.jpg', 'apple.jpg'])
+    assert set(df['stim'].unique()) == set(['obama.jpg', 'apple.jpg'])

--- a/pliers/tests/test_graph.py
+++ b/pliers/tests/test_graph.py
@@ -78,7 +78,7 @@ def test_small_pipeline():
     assert history.shape == (2, 8)
     assert history.iloc[0]['result_class'] == 'TextStim'
     result = merge_results(result)
-    assert (0, 'button.jpg->text[Exit]') in result.index
+    assert (0, 'text[Exit]') in result['stim'].values
     assert ('LengthExtractor', 'text_length') in result.columns
     assert result[('LengthExtractor', 'text_length')].values[0] == 4
 
@@ -90,7 +90,8 @@ def test_big_pipeline():
     visual_nodes = [(FrameSamplingConverter(every=15), 'framesampling',
                     [(TesseractConverter(), 'visual_text',
                     [(LengthExtractor(), 'visual_text_length')]),
-                    (VibranceExtractor(), 'visual_vibrance')])]
+                    (VibranceExtractor(), 'visual_vibrance'),
+                    (BrightnessExtractor(), 'brightness')])]
     audio_nodes = [(VideoToAudioConverter(), 'audio',
                     [(WitTranscriptionConverter(), 'audio_text',
                     [(LengthExtractor(), 'audio_text_length')])])]
@@ -101,5 +102,5 @@ def test_big_pipeline():
     assert ('LengthExtractor', 'text_length') in result.columns
     assert ('VibranceExtractor', 'vibrance') in result.columns
     assert not result[('onset', '')].isnull().any()
-    assert 'text[together]' in result.index.get_level_values(1)
-    assert 'obama_speech.mp4->frame[90]' in result.index.get_level_values(1)
+    assert 'text[together]' in result['stim'].values
+    assert 'frame[90]' in result['stim'].values

--- a/pliers/transformers.py
+++ b/pliers/transformers.py
@@ -108,6 +108,7 @@ class EnvironmentKeyMixin(object):
     def env_keys(self):
         return listify(self._env_keys)
 
+    @classproperty
     def available(cls):
         return True if all([k in os.environ for k in self.env_keys]) else False
 

--- a/pliers/transformers.py
+++ b/pliers/transformers.py
@@ -18,6 +18,7 @@ import os
 class Transformer(with_metaclass(ABCMeta)):
 
     _log_attributes = ()
+    _loggable = True
 
     def __init__(self, name=None):
         if name is None:
@@ -53,8 +54,8 @@ class Transformer(with_metaclass(ABCMeta)):
             if stims is not validated_stim:
                 return self.transform(validated_stim, *args, **kwargs)
             else:
-                result = self._transform(self._validate(stims), *args, **kwargs)
-                result = _log_transformation(stims, result, self)
+                result = self._transform(validated_stim, *args, **kwargs)
+                result = _log_transformation(validated_stim, result, self)
                 if isinstance(result, GeneratorType):
                     result = list(result)
                 return result

--- a/pliers/utils.py
+++ b/pliers/utils.py
@@ -20,3 +20,14 @@ def flatten(l):
                 yield sub
         else:
             yield el
+
+
+class classproperty(object):
+    ''' Implements a @classproperty decorator analogous to @classmethod.
+    Solution from: http://stackoverflow.com/questions/128573/using-property-on-classmethodss
+    '''
+    def __init__(self, fget):
+        self.fget = fget
+
+    def __get__(self, owner_self, owner_cls):
+        return self.fget(owner_cls)


### PR DESCRIPTION
This PR contains mostly minor fixes and improvements. The only (possibly) notable changes include:

* A new `EnvironmentKeyMixin` class that should be mixed into any `Transformer` that needs to use environment variables (mostly API keys for web services). This makes it easy to check whether the transformer is `.available` (i.e., all required environment keys are present).

* Default `Converter`s for any given pair of `Stim` types can now be set in the `config` module.

* Naming conventions have changed (yet again). `Stim`s now do *not* include any historical info in the name (e.g., video frames do not include the name of the source video). The reason for this is that `ExtractorResult`-derived DataFrames now return a bunch of info about stimulus class, history, etc., so using the `name` attribute for provenance seems unnecessary and just creates very long names.

* All `Transformer` classes now support a `._loggable` attribute that indicates whether or not they should be logged in each `Stim` history. This is a bit of a kludge to account for the fact that multistep converters were screwing up the history (because they contain multiple conversion steps internally, and were then overwriting the logging history with themselves at the end). `MultiStepConverter` hierarchy sets `_loggable` to `False`, otherwise it's currently `True` for all other `Transformer`s.

* `merge_results` now returns a slightly cleaner DataFrame.