### PR TITLE
Using io to open for encoding utf-8

### DIFF
--- a/pliers/datasets/text.py
+++ b/pliers/datasets/text.py
@@ -5,12 +5,12 @@ import os
 import tempfile
 import zipfile
 import shutil
-
+import io
 
 def _load_datasets():
     path = os.path.abspath(__file__)
     path = os.path.join(os.path.dirname(path), 'dictionaries.json')
-    dicts = json.load(open(path), encoding='utf-8')
+    dicts = json.load(io.open(path, encoding='utf-8'))
     return dicts
 
 datasets = _load_datasets()


### PR DESCRIPTION
Well I didn't mean to go down this path, but the downsampling of video was not going well on my measly laptop so I tried to do it on deepdream. 

For some reason, in windows when a file is in utf-8 encoding, that must be stated in `open`, and not in `json.load`. 

However, only python3 has different encodings in the `open` function. Turns out that you can make it python 2 and 3 compatible using open from the io library. Test seem to run well (aside from missing corpus ones for me). 