### PR TITLE
added new TensorFlowInceptionV3Extractor based on TF example

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_install:
 install:
 - pip install -r requirements.txt
 - pip install --upgrade --ignore-installed setuptools
-- pip install --upgrade coveralls pytest-cov pysrt xlrd clarifai pytesseract matplotlib SpeechRecognition IndicoIo tensorflow
+- pip install --upgrade coveralls pytest-cov pysrt xlrd clarifai seaborn pytesseract matplotlib SpeechRecognition IndicoIo tensorflow
 
 before_script:
   - python -m pliers.support.download

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: required
+dist: trusty
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ before_install:
 
 install:
 - pip install -r requirements.txt
+- pip install --upgrade --ignore-installed setuptools
 - pip install --upgrade coveralls pytest-cov pysrt xlrd clarifai pytesseract matplotlib SpeechRecognition IndicoIo tensorflow
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_install:
 
 install:
 - pip install -r requirements.txt
-- pip install --upgrade coveralls pytest-cov pysrt xlrd clarifai pytesseract matplotlib SpeechRecognition IndicoIo
+- pip install --upgrade coveralls pytest-cov pysrt xlrd clarifai pytesseract matplotlib SpeechRecognition IndicoIo tensorflow
 
 before_script:
   - python -m pliers.support.download

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ matrix:
          - MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh"
 
 before_install:
+- sudo add-apt-repository ppa:mc3man/trusty-media -y
 - export MINICONDA=$HOME/miniconda
 - export PATH="$MINICONDA/bin:$PATH"
 - hash -r
@@ -33,6 +34,8 @@ before_install:
 - conda config --add channels conda-forge
 - conda install python=$PYTHON_VERSION $CONDA_DEPS
 - sudo apt-get -qq update
+- sudo apt-get dist-upgrade
+- sudo apt-get install ffmpeg
 - sudo apt-get install tesseract-ocr
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
          - MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh"
 
 before_install:
-- sudo add-apt-repository ppa:mc3man/trusty-media -y
+- sudo add-apt-repository ppa:joyard-nicolas/ffmpeg -y
 - export MINICONDA=$HOME/miniconda
 - export PATH="$MINICONDA/bin:$PATH"
 - hash -r
@@ -34,7 +34,6 @@ before_install:
 - conda config --add channels conda-forge
 - conda install python=$PYTHON_VERSION $CONDA_DEPS
 - sudo apt-get -qq update
-- sudo apt-get dist-upgrade
 - sudo apt-get install ffmpeg
 - sudo apt-get install tesseract-ocr
 

--- a/optional-dependencies.txt
+++ b/optional-dependencies.txt
@@ -7,3 +7,4 @@ seaborn
 SpeechRecognition
 pytesseract
 IndicoIo
+tensorflow

--- a/optional-dependencies.txt
+++ b/optional-dependencies.txt
@@ -4,7 +4,7 @@ google-api-python-client
 matplotlib
 pysrt
 seaborn
-SpeechRecognition
+SpeechRecognition>=3.6.0
 pytesseract
 IndicoIo
 tensorflow

--- a/pliers/extractors/__init__.py
+++ b/pliers/extractors/__init__.py
@@ -6,6 +6,7 @@ from .google import (GoogleVisionAPIFaceExtractor,
                      GoogleVisionAPIPropertyExtractor)
 from .image import (BrightnessExtractor, SaliencyExtractor, SharpnessExtractor,
                     VibranceExtractor)
+from .models import TensorFlowInceptionV3Extractor
 from .text import (ComplexTextExtractor, DictionaryExtractor,
                    PredefinedDictionaryExtractor, LengthExtractor,
                    NumUniqueWordsExtractor, PartOfSpeechExtractor)
@@ -24,6 +25,7 @@ __all__ = [
     'SaliencyExtractor',
     'SharpnessExtractor',
     'VibranceExtractor',
+    'TensorFlowInceptionV3Extractor',
     'ComplexTextExtractor',
     'DictionaryExtractor',
     'PredefinedDictionaryExtractor',

--- a/pliers/extractors/models.py
+++ b/pliers/extractors/models.py
@@ -1,0 +1,85 @@
+from pliers.stimuli.image import ImageStim
+from pliers.extractors.base import Extractor, ExtractorResult
+import numpy as np
+import os
+import tempfile
+import sys
+import urllib
+import tarfile
+from scipy.misc import imsave
+import subprocess
+import re
+
+
+class TensorFlowInceptionV3Extractor(Extractor):
+
+    _input_type = ImageStim
+
+    def __init__(self, model_dir=None, data_url=None, num_predictions=5):
+
+        super(TensorFlowInceptionV3Extractor, self).__init__()
+
+        if model_dir is None:
+            model_dir = os.path.join(tempfile.gettempdir(), 'TFInceptionV3')
+        self.model_dir = model_dir
+
+        if data_url is None:
+            data_url = 'http://download.tensorflow.org/models/image/imagenet/inception-2015-12-05.tgz'
+        self.data_url = data_url
+
+        filename = self.data_url.split('/')[-1]
+        self.model_file = os.path.join(self.model_dir, filename)
+        self.num_predictions = num_predictions
+
+        # Download the inception-v3 model if needed
+        if not os.path.exists(self.model_file):
+            self._download_pretrained_model()
+
+    def _download_pretrained_model(self):
+        # Adapted from def_maybe_download_and_extract() in TF's classify_image.py
+        print("Downloading Inception-V3 model from TensorFlow website...")
+        if not os.path.exists(self.model_dir):
+            os.makedirs(self.model_dir)
+        filename = os.path.basename(self.model_file)
+        if not os.path.exists(self.model_file):
+            def _progress(count, block_size, total_size):
+                sys.stdout.write('\r>> Downloading %s %.1f%%' % (filename,
+                    float(count * block_size) / float(total_size) * 100.0))
+            sys.stdout.flush()
+            self.model_file, _ = urllib.request.urlretrieve(self.data_url,
+                                                self.model_file, _progress)
+            statinfo = os.stat(self.model_file)
+            print('\tSuccesfully downloaded', filename, statinfo.st_size, 'bytes.')
+        tarfile.open(self.model_file, 'r:gz').extractall(self.model_dir)
+
+    def _extract(self, stim):
+        import tensorflow as tf
+        tf_dir = os.path.dirname(tf.__file__)
+        script = os.path.join(tf_dir, 'models', 'image', 'imagenet', 'classify_image.py')
+        
+        if stim.filename is None:
+            img_file = tempfile.mktemp() + '.jpg'
+            imsave(img_file, stim.data)
+            use_tmp = True
+        else:
+            img_file = stim.filename
+            use_tmp = False
+
+        args = ' --image_file %s --model_dir %s --num_top_prediction %d' % \
+                (img_file, self.model_dir, self.num_predictions)
+        cmd = ('python ' + script + args).split()
+        process = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+        output, errors = process.communicate()
+        hits = output.decode('utf-8').splitlines()[-self.num_predictions:]
+        
+        values, features = [], []
+        for i, h in enumerate(hits):
+            m = re.search('(.*?)\s\(score\s\=\s([0-9\.]+)\)', h.strip())
+            values.extend(m.groups())
+            ind = i + 1
+            features.extend(['label_%d' % ind, 'score_%d' % ind])
+
+        if use_tmp:
+            os.remove(img_file)
+
+        return ExtractorResult([values], stim, self, features=features)

--- a/pliers/extractors/models.py
+++ b/pliers/extractors/models.py
@@ -4,7 +4,7 @@ import numpy as np
 import os
 import tempfile
 import sys
-import urllib
+import requests
 import tarfile
 from scipy.misc import imsave
 import subprocess
@@ -42,15 +42,12 @@ class TensorFlowInceptionV3Extractor(Extractor):
             os.makedirs(self.model_dir)
         filename = os.path.basename(self.model_file)
         if not os.path.exists(self.model_file):
-            def _progress(count, block_size, total_size):
-                sys.stdout.write('\r>> Downloading %s %.1f%%' % (filename,
-                    float(count * block_size) / float(total_size) * 100.0))
-            sys.stdout.flush()
-            self.model_file, _ = urllib.request.urlretrieve(self.data_url,
-                                                self.model_file, _progress)
-            statinfo = os.stat(self.model_file)
-            print('\tSuccesfully downloaded', filename, statinfo.st_size, 'bytes.')
-        tarfile.open(self.model_file, 'r:gz').extractall(self.model_dir)
+            r = requests.get(self.data_url)
+            with open(self.model_file, 'wb') as f:
+                f.write(r.content)
+            size = os.stat(self.model_file).st_size
+            print('\tSuccesfully downloaded', filename, size, 'bytes.')
+            tarfile.open(self.model_file, 'r:gz').extractall(self.model_dir)
 
     def _extract(self, stim):
         import tensorflow as tf

--- a/pliers/stimuli/audio.py
+++ b/pliers/stimuli/audio.py
@@ -14,7 +14,9 @@ class AudioStim(Stim):
 
         self._load_clip()
 
-        self.data = self.clip.to_soundarray()
+        # Small default buffer isn't ideal, but moviepy has persistent issues
+        # with some files otherwise; see https://github.com/Zulko/moviepy/issues/246
+        self.data = self.clip.to_soundarray(buffersize=1000)
         duration = self.clip.duration
 
         if self.data.ndim > 1:

--- a/pliers/tests/test_extractors.py
+++ b/pliers/tests/test_extractors.py
@@ -8,7 +8,7 @@ from pliers.extractors import (DictionaryExtractor, PartOfSpeechExtractor,
                                SharpnessExtractor,VibranceExtractor,
                                SaliencyExtractor, DenseOpticalFlowExtractor,
                                IndicoAPIExtractor, ClarifaiAPIExtractor,
-                               ComplexTextExtractor)
+                               ComplexTextExtractor, TensorFlowInceptionV3Extractor)
 from pliers.stimuli import (TextStim, ComplexTextStim, ImageStim, VideoStim,
                             AudioStim, TranscribedAudioCompoundStim)
 from pliers.support.download import download_nltk_data
@@ -284,3 +284,15 @@ def test_merge_extractor_results():
     assert df.columns.levels[0].unique().tolist() == de_names + cols
     assert df.columns.levels[1].unique().tolist() == ['duration', 0, 1, 2, '']
     assert set(df['stim'].unique()) == set(['obama.jpg', 'apple.jpg'])
+
+
+def test_tensor_flow_inception_v3_extractor():
+    image_dir = join(get_test_data_path(), 'image')
+    imgs = [join(image_dir, f) for f in ['apple.jpg', 'obama.jpg']]
+    imgs = [ImageStim(im) for im in imgs]
+    ext = TensorFlowInceptionV3Extractor()
+    results = ext.transform(imgs)
+    df = merge_results(results)
+    assert len(df) == 2
+    assert df.iloc[0][('TensorFlowInceptionV3Extractor', 'label_1')] == 'Granny Smith'
+    assert df.iloc[1][('TensorFlowInceptionV3Extractor', 'score_2')] == '0.17326'


### PR DESCRIPTION
This PR adds a new `extractors.models` submodule that will house Extractors based on pre-trained DNN models. I've added a new `TensorFlowInceptionV3Extractor` that does image labeling based on the pre-trained Inception V3 model discussed in the [TF docs](https://www.tensorflow.org/tutorials/image_recognition/#usage_with_python_api). See test for example usage, which follows the standard `Extractor` pattern. The 200 MB pretrained model will be downloaded the first time the extractor is run, if it' s not found, and no additional code is required.