### PR TITLE
General improvements and fixes

### DIFF
--- a/pliers/config.py
+++ b/pliers/config.py
@@ -3,6 +3,7 @@ cache_converters = False
 cache_filters = False
 cache_extractors = False
 log_transformations = True
+drop_bad_extractor_results = True
 default_converters = {
     'AudioStim->TextStim': ('IBMSpeechAPIConverter', 'WitTranscriptionConverter')
 }

--- a/pliers/converters/google.py
+++ b/pliers/converters/google.py
@@ -40,4 +40,4 @@ class GoogleVisionAPITextConverter(GoogleVisionAPITransformer, ImageToTextConver
                 return texts
             
         else:
-            return TextStim(text='')
+            return TextStim(text='', onset=stim.onset, duration=stim.duration)

--- a/pliers/extractors/api.py
+++ b/pliers/extractors/api.py
@@ -3,8 +3,8 @@ Extractors that interact with external (e.g., deep learning) services.
 '''
 
 from pliers.extractors.image import ImageExtractor
-from pliers.extractors.text import ComplexTextExtractor
-from pliers.extractors.base import ExtractorResult
+from pliers.extractors.base import Extractor, ExtractorResult
+from pliers.stimuli.text import TextStim, ComplexTextStim
 from scipy.misc import imsave
 import os
 import tempfile
@@ -19,7 +19,7 @@ try:
 except ImportError:
     pass
 
-class IndicoAPIExtractor(ComplexTextExtractor):
+class IndicoAPIExtractor(Extractor):
 
     ''' Uses the Indico API to extract sentiment of text.
     Args:
@@ -29,9 +29,11 @@ class IndicoAPIExtractor(ComplexTextExtractor):
     '''
 
     _log_attributes = ('models',)
+    _input_type = ()
+    _optional_input_type = (TextStim, ComplexTextStim)
 
     def __init__(self, api_key=None, models=None):
-        ComplexTextExtractor.__init__(self)
+        super(IndicoAPIExtractor, self).__init__()
         if api_key is None:
             try:
                 self.api_key = os.environ['INDICO_APP_KEY']
@@ -56,6 +58,8 @@ class IndicoAPIExtractor(ComplexTextExtractor):
                                 "twitter_engagement, personality, personas, text_features")
 
     def _extract(self, stim):
+        if isinstance(stim, TextStim):
+            stim = [stim]
         tokens = [token.text for token in stim]
         scores = [model(tokens) for model in self.models]
         data = []

--- a/pliers/extractors/base.py
+++ b/pliers/extractors/base.py
@@ -35,10 +35,20 @@ class ExtractorResult(object):
     def __init__(self, data, stim, extractor, features=None, onsets=None,
                  durations=None):
         self.data = data
-        self.stim = stim
         self.extractor = extractor
         self.features = features
         self._history = None
+
+        # Some Extractors pass a list of Stims for various reasons
+        if isinstance(stim, (list, tuple)):
+            if not len(set(stim)) == 1:
+                raise ValueError("Multiple Stim instances passed to the 'stim'"
+                                 " argument in ExtractorResult initialization;"
+                                 " each ExtractorResult can only be associated"
+                                 " with a single Stim.")
+            stim = stim[0]
+        self.stim = stim
+
         if onsets is None:
             onsets = stim.onset
         self.onsets = onsets if onsets is not None else np.nan
@@ -136,6 +146,8 @@ def merge_results(results, extractor_names=True, stim_names=True):
     Returns: a pandas DataFrame with features concatenated along the column
         axis and stims concatenated along the row axis.
     '''
+
+
 
     stims = defaultdict(list)
 

--- a/pliers/graph.py
+++ b/pliers/graph.py
@@ -68,9 +68,9 @@ class Graph(Node):
         if isinstance(node, (list, tuple)):
             kwargs['transformer'] = node[0]
             if len(node) > 1:
-                kwargs['name'] = node[1]
+                kwargs['children'] = node[1]
             if len(node) > 2:
-                kwargs['children'] = node[2]
+                kwargs['name'] = node[2]
         else:
             kwargs['transformer'] = node
 

--- a/pliers/stimuli/base.py
+++ b/pliers/stimuli/base.py
@@ -106,7 +106,8 @@ def load_stims(source, dtype=None):
 
 def _log_transformation(source, result, trans=None):
 
-    if not config.log_transformations or (trans is not None and not trans._loggable):
+    if result is None or not config.log_transformations or \
+              (trans is not None and not trans._loggable):
         return result
 
     if isinstance(result, (list, tuple, GeneratorType)):

--- a/pliers/stimuli/compound.py
+++ b/pliers/stimuli/compound.py
@@ -69,16 +69,23 @@ class CompoundStim(object):
             return [] if return_all else None
         return matches
 
-    def has_types(self, types):
+    def get_types(self):
+        ''' Return tuple of types of all available Stims. '''
+        return tuple(set([e.__class__ for e in self.elements]))
+
+    def has_types(self, types, all_=True):
         ''' Check whether the current component list matches all Stim types
         in the types argument.
         Args:
             types (Stim, list): a Stim class or iterable of Stim classes.
+            all_ (bool): if True, all input types must match; if False, at least
+                one input type must match.
         Return:
             True if all passed types match at least one Stim in the component
             list, otherwise False.
         '''
-        return all([self.get_stim(t) for t in listify(types)])
+        func = all if all_ else any
+        return func([self.get_stim(t) for t in listify(types)])
 
     def __getattr__(self, attr):
         try:

--- a/pliers/stimuli/text.py
+++ b/pliers/stimuli/text.py
@@ -14,8 +14,7 @@ class TextStim(Stim):
         if filename is not None and text is None:
             text = open(filename).read()
         self.text = text
-        label = 'text[%s]' % text[:20]  # Truncate at 20 chars
-        name = label if filename is None else filename + '->' + label
+        name = 'text[%s]' % text[:40]  # Truncate at 40 chars
         super(TextStim, self).__init__(filename, onset, duration, name)
 
 

--- a/pliers/tests/test_extractors.py
+++ b/pliers/tests/test_extractors.py
@@ -209,11 +209,12 @@ def test_optical_flow_extractor():
 @pytest.mark.skipif("'INDICO_APP_KEY' not in os.environ")
 def test_indico_api_extractor():
 
+    ext = IndicoAPIExtractor(api_key=os.environ['INDICO_APP_KEY'],
+                             models=['emotion', 'personality'])
+
     # With ComplexTextStim input
     srtfile = join(get_test_data_path(), 'text', 'wonderful.srt')
     srt_stim = ComplexTextStim(srtfile)
-    ext = IndicoAPIExtractor(
-        api_key=os.environ['INDICO_APP_KEY'], models=['emotion', 'personality'])
     result = ext.transform(srt_stim).to_df()
     outdfKeysCheck = set([
         'onset',
@@ -233,6 +234,7 @@ def test_indico_api_extractor():
     ts = TextStim(text="It's a wonderful life.")
     result = ext.transform(ts).to_df()
     assert set(result.columns) == outdfKeysCheck
+    assert len(result) == 1
 
 
 @pytest.mark.skipif("'CLARIFAI_APP_ID' not in os.environ")

--- a/pliers/tests/test_extractors.py
+++ b/pliers/tests/test_extractors.py
@@ -207,7 +207,9 @@ def test_optical_flow_extractor():
 
 
 @pytest.mark.skipif("'INDICO_APP_KEY' not in os.environ")
-def test_indicoAPI_extractor():
+def test_indico_api_extractor():
+
+    # With ComplexTextStim input
     srtfile = join(get_test_data_path(), 'text', 'wonderful.srt')
     srt_stim = ComplexTextStim(srtfile)
     ext = IndicoAPIExtractor(
@@ -227,9 +229,14 @@ def test_indicoAPI_extractor():
         'personality_conscientiousness'])
     assert set(result.columns) == outdfKeysCheck
 
+    # With TextStim input
+    ts = TextStim(text="It's a wonderful life.")
+    result = ext.transform(ts).to_df()
+    assert set(result.columns) == outdfKeysCheck
+
 
 @pytest.mark.skipif("'CLARIFAI_APP_ID' not in os.environ")
-def test_clarifaiAPI_extractor():
+def test_clarifai_api_extractor():
     image_dir = join(get_test_data_path(), 'image')
     stim = ImageStim(join(image_dir, 'apple.jpg'))
     result = ClarifaiAPIExtractor().transform(stim).to_df()

--- a/pliers/transformers.py
+++ b/pliers/transformers.py
@@ -49,9 +49,13 @@ class Transformer(with_metaclass(ABCMeta)):
                 raise ValueError("No stims of class %s found in the provided"
                                  "CompoundStim instance." % self._input_type)
 
-        # If stims is an iterable, naively loop over elements.
+        # If stims is an iterable, naively loop over elements, removing
+        # invalid results if needed
         if isinstance(stims, (list, tuple, GeneratorType)):
-            return self._iterate(stims, *args, **kwargs)
+            iters = self._iterate(stims, *args, **kwargs)
+            if config.drop_bad_extractor_results:
+                return (i for i in iters if i is not None)
+            return iters
 
         # Validate stim, and then either pass it directly to the Transformer
         # or, if a conversion occurred, recurse.


### PR DESCRIPTION
This PR closes several issues and adds some other improvements:

* Every `Transformer` class now has an `_optional_input_types` property (which can almost always be ignored and left to use the empty value in the base `Transformer` class) that specifies which input `Stim` classes are acceptable but not required. This closes #105 and allows creation of `Transformer` classes that can handle one of several different `Stim` inputs (e.g., the `IndicoAPIExtractor` can batch-submit documents, so it can now handle both `ComplexTextStim` and `TextStim` inputs, behaving more efficiently in the former case).

* In `graph.py`, the order of the arguments to `_parse_node_args` has been changed from `(Transformer, name, children)` to `(Transformer, children, name)`, because the `name` attribute is almost never needed in practice, whereas the `children` argument is passed quite often. This makes complex `Graph` specifications much less verbose.

* Any `Extractor` can now return a `None` value instead of an `ExtractorResult`. This is inelegant in one sense, but makes it much easier to handle cases where an `Extractor` is passed a `Stim` that it can't do anything with, as we no longer have to return empty containers (which are sometimes hard to generate--e.g., because one doesn't know what the column names will be unless an API service actually returns a valid result). To prevent this from causing downstream problems, there's now a new `config` flag that specifies whether or not to automatically and silently `drop_bad_extractor_results` (default: `True`).

* Issue #115 is fixed; some `Extractor` classes will pass a list of `Stim` instead of just one `Stim` to the `stim` argument of the `ExtractorResult` initializer, and this is probably hard to avoid without changing some of the `Transformer` logic. So we now check for this inside the `ExtractorResult` init and adjust accordingly.
