### PR TITLE
Added datasets to package_data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
                       'pillow', 'python-magic', 'requests', 'nltk'],
     packages=find_packages(exclude=['pliers/tests']),
     license='MIT',
-    package_data={'pliers': ['data/*'],
+    package_data={'pliers': ['datasets/*'],
                   'pliers.tests': ['data/*/*']
                   },
     download_url='https://github.com/tyarkoni/pliers/archive/%s.tar.gz' %


### PR DESCRIPTION
In #113 package data was not being copied over during install in regular installs. 

Looks like the issue was `package_data` in `setup.py` was fetching pliers/data but dictionaries.json is in pliers/datasets.

This fixed it on osx, windows and linux for me. 