### PR TITLE
Graph plotting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ matrix:
 before_install:
 - sudo add-apt-repository ppa:joyard-nicolas/ffmpeg -y
 - sudo apt-get -qq update
-- sudo apt-get install ffmpeg
-- sudo apt-get install tesseract-ocr
+- sudo apt-get install ffmpeg tesseract-ocr graphviz
+
 
 - export MINICONDA=$HOME/miniconda
 - export PATH="$MINICONDA/bin:$PATH"
@@ -42,7 +42,8 @@ before_install:
 install:
 - pip install -r requirements.txt
 - pip install --upgrade --ignore-installed setuptools
-- pip install --upgrade coveralls pytest-cov pysrt xlrd clarifai seaborn pytesseract matplotlib SpeechRecognition IndicoIo tensorflow
+- pip install --upgrade coveralls pytest-cov pysrt xlrd clarifai seaborn pytesseract
+- pip install --upgrade matplotlib SpeechRecognition IndicoIo tensorflow pygraphviz
 - pip install 'numpy<1.12.0'
 
 before_script:

--- a/optional-dependencies.txt
+++ b/optional-dependencies.txt
@@ -2,6 +2,7 @@ clarifai
 cv2
 google-api-python-client
 matplotlib
+pygraphviz
 pysrt
 seaborn
 SpeechRecognition>=3.6.0

--- a/pliers/extractors/audio.py
+++ b/pliers/extractors/audio.py
@@ -51,7 +51,7 @@ class STFTAudioExtractor(AudioExtractor):
         w = np.hanning(framesamp)
         X = np.array([fft(w*x[i:(i+framesamp)])
                       for i in range(0, len(x)-framesamp, hopsamp)])
-        nyquist_lim = X.shape[1]//2
+        nyquist_lim = int(X.shape[1]//2)
         X = np.log(X[:, :nyquist_lim])
         X = np.absolute(X)
         if self.spectrogram:

--- a/pliers/stimuli/base.py
+++ b/pliers/stimuli/base.py
@@ -141,6 +141,7 @@ def _log_transformation(source, result, trans=None):
     result.history = TransformationLog(*values)
     return result
 
+
 class TransformationLog(namedtuple('TransformationLog', "source_name source_file " +
                              "source_class result_name result_file result_class " +
                              " transformer_class transformer_params string parent")):

--- a/pliers/tests/test_graph.py
+++ b/pliers/tests/test_graph.py
@@ -6,9 +6,11 @@ from pliers.extractors import (BrightnessExtractor, VibranceExtractor,
                                LengthExtractor, merge_results)
 from pliers.stimuli import (ImageStim, VideoStim)
 from .utils import get_test_data_path, DummyExtractor
-from os.path import join
+from os.path import join, exists
 import numpy as np
 from numpy.testing import assert_almost_equal
+import tempfile
+import os
 
 
 def test_node_init():
@@ -84,6 +86,7 @@ def test_small_pipeline():
 
 @pytest.mark.skipif("'WIT_AI_API_KEY' not in os.environ")
 def test_big_pipeline():
+    pytest.importorskip('pygraphviz')
     filename = join(get_test_data_path(), 'video', 'obama_speech.mp4')
     video = VideoStim(filename)
     visual_nodes = [(FrameSamplingConverter(every=15), [
@@ -97,6 +100,11 @@ def test_big_pipeline():
     graph.add_nodes(visual_nodes)
     graph.add_nodes(audio_nodes)
     result = graph.run(video)
+    # Test that pygraphviz outputs a file
+    drawfile = next(tempfile._get_candidate_names())
+    graph.draw(drawfile)
+    assert exists(drawfile)
+    os.remove(drawfile)
     assert ('LengthExtractor', 'text_length') in result.columns
     assert ('VibranceExtractor', 'vibrance') in result.columns
     # assert not result[('onset', '')].isnull().any()


### PR DESCRIPTION
Adds basic support for graph plotting. When calling `.draw()` on a `Graph` instance that's already been executed at least once (i.e., by calling `.run()`), a graph diagram of all transformations is generated via pygraphviz. Here's what it looks like for the `Graph` constructed in one of the tests:

![graph](https://cloud.githubusercontent.com/assets/303932/22815346/7d695490-ef20-11e6-88e0-ce1590b560c0.png)

We probably want to tweak this some more; e.g., it would be nice to differentiate between explicit transformations and implicit conversions, treat all of the different ExtractorResult nodes as a single node, etc... But for now, I think this is already quite useful.