### PR TITLE
Indico image extractors

### DIFF
--- a/pliers/extractors/__init__.py
+++ b/pliers/extractors/__init__.py
@@ -1,7 +1,7 @@
 ''' Extractor hierarchy. '''
 
 from .base import ExtractorResult, merge_results
-from .api import IndicoAPIExtractor, ClarifaiAPIExtractor
+from .api import IndicoAPITextExtractor, ClarifaiAPIExtractor
 from .audio import STFTAudioExtractor, MeanAmplitudeExtractor
 from .google import (GoogleVisionAPIFaceExtractor,
                      GoogleVisionAPILabelExtractor,

--- a/pliers/extractors/__init__.py
+++ b/pliers/extractors/__init__.py
@@ -16,7 +16,8 @@ from .video import (DenseOpticalFlowExtractor)
 
 __all__ = [
     'ExtractorResult',
-    'IndicoAPIExtractor',
+    'IndicoAPITextExtractor',
+    'IndicoAPIImageExtractor',
     'ClarifaiAPIExtractor',
     'STFTAudioExtractor',
     'MeanAmplitudeExtractor',

--- a/pliers/extractors/__init__.py
+++ b/pliers/extractors/__init__.py
@@ -1,7 +1,7 @@
 ''' Extractor hierarchy. '''
 
 from .base import ExtractorResult, merge_results
-from .api import IndicoAPITextExtractor, ClarifaiAPIExtractor
+from .api import IndicoAPITextExtractor, IndicoAPIImageExtractor, ClarifaiAPIExtractor
 from .audio import STFTAudioExtractor, MeanAmplitudeExtractor
 from .google import (GoogleVisionAPIFaceExtractor,
                      GoogleVisionAPILabelExtractor,

--- a/pliers/extractors/api.py
+++ b/pliers/extractors/api.py
@@ -76,7 +76,7 @@ class IndicoAPITextExtractor(IndicoAPIExtractor):
     _optional_input_type = (TextStim, ComplexTextStim)
 
     def __init__(self, api_key=None, models=None):
-        super(IndicoAPITextExtractor, self).__init__()
+        super(IndicoAPITextExtractor, self).__init__(api_key, models)
 
     def _extract(self, stim):
 

--- a/pliers/extractors/api.py
+++ b/pliers/extractors/api.py
@@ -16,7 +16,7 @@ except ImportError:
     pass
 
 try:
-        import indicoio as ico
+    import indicoio as ico
 except ImportError:
     pass
 
@@ -33,7 +33,6 @@ class IndicoAPIExtractor(Extractor):
 
     _log_attributes = ('models',)
     _input_type = ()
-    _optional_input_type = (TextStim, ComplexTextStim)
 
     def __init__(self, api_key=None, models=None):
         super(IndicoAPIExtractor, self).__init__()
@@ -47,6 +46,7 @@ class IndicoAPIExtractor(Extractor):
         else:
             self.api_key = api_key
         ico.config.api_key = self.api_key
+
         if models is None:
             raise ValueError("Must enter a valid list of models to use of "
                              "possible types: sentiment, sentiment_hq, emotion.")
@@ -59,7 +59,7 @@ class IndicoAPIExtractor(Extractor):
         self.models = [getattr(ico, model) for model in models]
         self.names = models
 
-    def _extract(self, stim, scores):
+    def _annotate(self, stim, scores):
         data, onsets, durations = [], [], []
 
         for i, s in enumerate(stim):
@@ -109,7 +109,7 @@ class IndicoAPITextExtractor(IndicoAPIExtractor):
         tokens = [token.text for token in stim if token.text]
         scores = [model(tokens) for model in self.models]
 
-        super(IndicoAPITextExtractor, self)._extract(stim, scores)
+        return self._annotate(stim, scores)
 
 
 class ClarifaiAPIExtractor(ImageExtractor):

--- a/pliers/extractors/api.py
+++ b/pliers/extractors/api.py
@@ -49,12 +49,12 @@ class IndicoAPIExtractor(Extractor):
 
         if models is None:
             raise ValueError("Must enter a valid list of models to use of "
-                             "possible types: sentiment, sentiment_hq, emotion.")
+                             "possible types{}".format(model, ", ".join(self.allowed_models)))
         for model in models:
             if model not in self.allowed_models:
                 raise ValueError(
-                "Unsupported model {} specified. Must use one or more "
-                "of the following: {}".format(model, ", ".join(self.allowed_models)))
+                "Unsupported model {} specified. "
+                "Valid models: {}".format(model, ", ".join(self.allowed_models)))
 
         self.models = [getattr(ico, model) for model in models]
         self.names = models

--- a/pliers/extractors/api.py
+++ b/pliers/extractors/api.py
@@ -59,6 +59,32 @@ class IndicoAPIExtractor(Extractor):
         self.models = [getattr(ico, model) for model in models]
         self.names = models
 
+    def _extract(self, stim):
+        scores = [model(stim) for model in self.models]
+
+        data, onsets, durations = [], [], []
+
+        for i, s in enumerate(stim):
+            features, values = [], []
+            for j, score in enumerate(scores):
+                if isinstance(score[i], float):
+                    features.append(self.names[j])
+                    values.append(score[i])
+                elif isinstance(score[i], dict):
+                    for k in score[i].keys():
+                        features.append(self.names[j] + '_' + k)
+                        values.append(score[i][k])
+
+            data.append(values)
+            onsets.append(s.onset)
+            durations.append(s.duration)
+
+        if not data:
+            data = []
+
+        return ExtractorResult(data, stim, self, features=features,
+                               onsets=onsets, durations=durations)
+
 class IndicoAPITextExtractor(IndicoAPIExtractor):
 
     ''' Base class for all Indico API Extractors that work on text, such as
@@ -84,30 +110,8 @@ class IndicoAPITextExtractor(IndicoAPIExtractor):
             stim = [stim]
 
         tokens = [token.text for token in stim if token.text]
-        scores = [model(tokens) for model in self.models]
 
-        data, onsets, durations = [], [], []
-
-        for i, s in enumerate(stim):
-            features, values = [], []
-            for j, score in enumerate(scores):
-                if isinstance(score[i], float):
-                    features.append(self.names[j])
-                    values.append(score[i])
-                elif isinstance(score[i], dict):
-                    for k in score[i].keys():
-                        features.append(self.names[j] + '_' + k)
-                        values.append(score[i][k])
-
-            data.append(values)
-            onsets.append(s.onset)
-            durations.append(s.duration)
-
-        if not data:
-            data = []
-
-        return ExtractorResult(data, stim, self, features=features,
-                               onsets=onsets, durations=durations)
+        super(IndicoAPITextExtractor, self)._extract(tokens)
 
 
 class ClarifaiAPIExtractor(ImageExtractor):

--- a/pliers/extractors/api.py
+++ b/pliers/extractors/api.py
@@ -23,7 +23,8 @@ except ImportError:
 
 class IndicoAPIExtractor(Extractor):
 
-    ''' Uses the Indico API to extract sentiment of text.
+    ''' Base class for all Indico API Extractors
+
     Args:
         api_key (str): A valid API key for the Indico API. Only needs to be
             passed the first time the extractor is initialized.
@@ -60,6 +61,22 @@ class IndicoAPIExtractor(Extractor):
                        "places, organizations, twitter_engagement, "
                        "personality, personas, text_features.")
                 raise ValueError(msg)
+
+class IndicoAPITextExtractor(IndicoAPIExtractor):
+
+    ''' Base class for all Indico API Extractors that work on text, such as
+    sentiment extraction.
+
+    Args:
+        api_key (str): A valid API key for the Indico API. Only needs to be
+            passed the first time the extractor is initialized.
+        models (list): The names of the Indico models to use.
+    '''
+
+    _optional_input_type = (TextStim, ComplexTextStim)
+
+    def __init__(self, api_key=None, models=None):
+        super(IndicoAPITextExtractor, self).__init__()
 
     def _extract(self, stim):
 

--- a/pliers/extractors/api.py
+++ b/pliers/extractors/api.py
@@ -59,9 +59,7 @@ class IndicoAPIExtractor(Extractor):
         self.models = [getattr(ico, model) for model in models]
         self.names = models
 
-    def _extract(self, stim):
-        scores = [model(stim) for model in self.models]
-
+    def _extract(self, stim, scores):
         data, onsets, durations = [], [], []
 
         for i, s in enumerate(stim):
@@ -103,15 +101,15 @@ class IndicoAPITextExtractor(IndicoAPIExtractor):
         super(IndicoAPITextExtractor, self).__init__(api_key, models)
 
     def _extract(self, stim):
-
         if isinstance(stim, TextStim):
             if not stim.text:
                 return None
             stim = [stim]
 
         tokens = [token.text for token in stim if token.text]
+        scores = [model(tokens) for model in self.models]
 
-        super(IndicoAPITextExtractor, self)._extract(tokens)
+        super(IndicoAPITextExtractor, self)._extract(stim, scores)
 
 
 class ClarifaiAPIExtractor(ImageExtractor):

--- a/pliers/extractors/api.py
+++ b/pliers/extractors/api.py
@@ -16,7 +16,7 @@ except ImportError:
     pass
 
 try:
-    import indicoio as ico
+        import indicoio as ico
 except ImportError:
     pass
 
@@ -50,17 +50,14 @@ class IndicoAPIExtractor(Extractor):
         if models is None:
             raise ValueError("Must enter a valid list of models to use of "
                              "possible types: sentiment, sentiment_hq, emotion.")
-        else:
-            try:
-                self.models = [getattr(ico, model) for model in models]
-                self.names = models
-            except AttributeError:
-                msg = ("Unsupported model(s) specified. Must use one or more "
-                       "of the following: sentiment, sentiment_hq, emotion, "
-                       "text_tags, language, political, keywords, people, "
-                       "places, organizations, twitter_engagement, "
-                       "personality, personas, text_features.")
-                raise ValueError(msg)
+        for model in models:
+            if model not in self.allowed_models:
+                raise ValueError(
+                "Unsupported model {} specified. Must use one or more "
+                "of the following: {}".format(model, ", ".join(self.allowed_models)))
+
+        self.models = [getattr(ico, model) for model in models]
+        self.names = models
 
 class IndicoAPITextExtractor(IndicoAPIExtractor):
 
@@ -76,6 +73,7 @@ class IndicoAPITextExtractor(IndicoAPIExtractor):
     _optional_input_type = (TextStim, ComplexTextStim)
 
     def __init__(self, api_key=None, models=None):
+        self.allowed_models = ico.TEXT_APIS.keys()
         super(IndicoAPITextExtractor, self).__init__(api_key, models)
 
     def _extract(self, stim):

--- a/pliers/tests/test_extractors.py
+++ b/pliers/tests/test_extractors.py
@@ -7,7 +7,7 @@ from pliers.extractors import (DictionaryExtractor, PartOfSpeechExtractor,
                                MeanAmplitudeExtractor, BrightnessExtractor,
                                SharpnessExtractor, VibranceExtractor,
                                SaliencyExtractor, DenseOpticalFlowExtractor,
-                               IndicoAPIExtractor, ClarifaiAPIExtractor,
+                               IndicoAPITextExtractor, ClarifaiAPIExtractor,
                                TensorFlowInceptionV3Extractor)
 from pliers.stimuli import (TextStim, ComplexTextStim, ImageStim, VideoStim,
                             AudioStim, TranscribedAudioCompoundStim)
@@ -207,9 +207,9 @@ def test_optical_flow_extractor():
 
 
 @pytest.mark.skipif("'INDICO_APP_KEY' not in os.environ")
-def test_indico_api_extractor():
+def test_indico_api_text_extractor():
 
-    ext = IndicoAPIExtractor(api_key=os.environ['INDICO_APP_KEY'],
+    ext = IndicoAPITextExtractor(api_key=os.environ['INDICO_APP_KEY'],
                              models=['emotion', 'personality'])
 
     # With ComplexTextStim input

--- a/pliers/tests/test_extractors.py
+++ b/pliers/tests/test_extractors.py
@@ -7,7 +7,8 @@ from pliers.extractors import (DictionaryExtractor, PartOfSpeechExtractor,
                                MeanAmplitudeExtractor, BrightnessExtractor,
                                SharpnessExtractor, VibranceExtractor,
                                SaliencyExtractor, DenseOpticalFlowExtractor,
-                               IndicoAPITextExtractor, ClarifaiAPIExtractor,
+                               IndicoAPITextExtractor, IndicoAPIImageExtractor,
+                               ClarifaiAPIExtractor,
                                TensorFlowInceptionV3Extractor)
 from pliers.stimuli import (TextStim, ComplexTextStim, ImageStim, VideoStim,
                             AudioStim, TranscribedAudioCompoundStim)
@@ -236,6 +237,34 @@ def test_indico_api_text_extractor():
     assert set(result.columns) == outdfKeysCheck
     assert len(result) == 1
 
+
+@pytest.mark.skipif("'INDICO_APP_KEY' not in os.environ")
+def test_indico_api_image_extractor():
+
+    ext = IndicoAPIImageExtractor(api_key=os.environ['INDICO_APP_KEY'],
+                             models=['fer', 'content_filtering'])
+
+    image_dir = join(get_test_data_path(), 'image')
+    stim1 = ImageStim(join(image_dir, 'apple.jpg'))
+    result1 = ext.transform(stim1).to_df()
+
+    outdfKeysCheck = set(['onset',
+        'duration',
+        'fer_Surprise',
+        'fer_Neutral',
+        'fer_Sad',
+        'fer_Happy',
+        'fer_Angry',
+        'fer_Fear',
+        'content_filtering'])
+
+    assert set(result1.columns) == outdfKeysCheck
+    assert result1['content_filtering'][0] < 0.1
+
+    stim2 = ImageStim(join(image_dir, 'obama.jpg'))
+    result2 = ext.transform(stim2).to_df()
+    assert set(result2.columns) == outdfKeysCheck
+    assert result2['fer_Happy'][0] > 0.7
 
 @pytest.mark.skipif("'CLARIFAI_APP_ID' not in os.environ")
 def test_clarifai_api_extractor():


### PR DESCRIPTION
This is work in progress to address #144 

I've mostly focused on creating a base Indico class, and specialized Image and Text classes. Tests are passing for text. But I wanted to open this issue to discuss the fact that for Text, you can now choose the unit of analysis (e.g. word, or phrase). Ideally, we want to abstract away that piece of logic, so that the scorer/annotator can do its job for all. I suppose for VideoStims you could potentially also choose what the unit of analysis is, but right now that is being done by the implicit conversion to ImageStim at some sampling rate. 

Sounds like @qmac implemented it the same way for TextStim so we should be set. 