### PR TITLE
Moved temp file management to stim classes

### DIFF
--- a/pliers/google.py
+++ b/pliers/google.py
@@ -1,7 +1,5 @@
 import base64
 import os
-import tempfile
-from scipy.misc import imsave
 from pliers.transformers import (Transformer, BatchTransformerMixin,
                                  EnvironmentKeyMixin)
 
@@ -56,13 +54,10 @@ class GoogleVisionAPITransformer(GoogleAPITransformer):
     def _build_request(self, stims):
         request = []
         for image in stims:
-            if image.filename is None:
-                file = tempfile.mktemp() + '.png'
-                imsave(file, image.data)
-            else:
-                file = image.filename
+            with image.get_filename() as filename:
+                with open(filename, 'rb') as f:
+                    img_data = f.read()
 
-            img_data = open(file, 'rb').read()
             content = base64.b64encode(img_data).decode()
             request.append(
                 {
@@ -73,6 +68,4 @@ class GoogleVisionAPITransformer(GoogleAPITransformer):
                     }]
                 })
 
-            if image.filename is None:
-                os.remove(file)
         return request

--- a/pliers/stimuli/audio.py
+++ b/pliers/stimuli/audio.py
@@ -2,6 +2,9 @@
 
 from .base import Stim
 from moviepy.audio.io.AudioFileClip import AudioFileClip
+from contextlib import contextmanager
+import tempfile
+import os
 
 
 class AudioStim(Stim):
@@ -50,3 +53,13 @@ class AudioStim(Stim):
     def __setstate__(self, d):
         self.__dict__ = d
         self._load_clip()
+
+    @contextmanager
+    def get_filename(self):
+        if self.filename is None or not os.path.exists(self.filename):
+            tf = tempfile.mktemp() + '.wav'
+            self.clip.write_audiofile(tf)
+            yield tf
+            os.remove(tf)
+        else:
+            yield self.filename

--- a/pliers/stimuli/image.py
+++ b/pliers/stimuli/image.py
@@ -3,10 +3,14 @@
 from .base import Stim
 from scipy.misc import imread
 from PIL import Image
+from six.moves.urllib.request import urlopen
+from contextlib import contextmanager
+from scipy.misc import imsave
 import six
 import io
+import os
+import tempfile
 import numpy as np
-from six.moves.urllib.request import urlopen
 
 
 class ImageStim(Stim):
@@ -31,3 +35,13 @@ class ImageStim(Stim):
             filename = url
         self.data = data
         super(ImageStim, self).__init__(filename, onset=onset, duration=duration)
+
+    @contextmanager
+    def get_filename(self):
+        if self.filename is None or not os.path.exists(self.filename):
+            tf = tempfile.mktemp() + '.png'
+            imsave(tf, self.data)
+            yield tf
+            os.remove(tf)
+        else:
+            yield self.filename

--- a/pliers/stimuli/video.py
+++ b/pliers/stimuli/video.py
@@ -4,6 +4,9 @@ from __future__ import division
 from moviepy.video.io.VideoFileClip import VideoFileClip
 from .base import Stim, CollectionStimMixin
 from .image import ImageStim
+from contextlib import contextmanager
+import os
+import tempfile
 
 
 class VideoFrameStim(ImageStim):
@@ -80,6 +83,16 @@ class VideoStim(Stim, CollectionStimMixin):
         else:
             index = int(onset * self.fps)
         return VideoFrameStim(self, index, data=self.clip.get_frame(onset))
+
+    @contextmanager
+    def get_filename(self):
+        if self.filename is None or not os.path.exists(self.filename):
+            tf = tempfile.mktemp() + '.mp4'
+            self.clip.write_videofile(tf)
+            yield tf
+            os.remove(tf)
+        else:
+            yield self.filename
 
 
 class DerivedVideoStim(VideoStim):

--- a/pliers/tests/test_stims.py
+++ b/pliers/tests/test_stims.py
@@ -8,7 +8,7 @@ from pliers.extractors import BrightnessExtractor
 from pliers.extractors.base import Extractor, ExtractorResult
 from pliers.support.download import download_nltk_data
 import numpy as np
-from os.path import join
+from os.path import join, exists
 import pandas as pd
 import pytest
 
@@ -193,3 +193,17 @@ def test_remote_stims():
     url = 'https://github.com/tyarkoni/pliers/blob/master/README.md'
     text = TextStim(url=url)
     assert len(text.text) > 1
+
+
+def test_get_filename():
+    url = 'http://www.bobainsworth.com/wav/simpsons/themodyn.wav'
+    audio = AudioStim(url=url)
+    with audio.get_filename() as filename:
+        assert exists(filename)
+    assert not exists(filename)
+
+    url = 'https://tuition.utexas.edu/sites/all/themes/tuition/logo.png'
+    image = ImageStim(url=url)
+    with image.get_filename() as filename:
+        assert exists(filename)
+    assert not exists(filename)


### PR DESCRIPTION
Many transformers require a local file to work. Previously, we just created a temp file on the fly in the transformer logic. This PR moves the logic to a `get_filename` method in the stim classes, to prevent code reuse.