### PR TITLE
Fix for Python3 travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,8 @@ before_install:
 
 install:
 - pip install --upgrade --ignore-installed setuptools
-- pip install python-magic moviepy coveralls pytest-cov pysrt xlrd clarifai pytesseract
+- pip install python-magic coveralls pytest-cov pysrt xlrd clarifai pytesseract
+- pip install moviepy==0.2.2.13
 - pip install SpeechRecognition IndicoIo pygraphviz
 
 before_script:


### PR DESCRIPTION
Using older version (0.2.2.13) of moviepy.
Based on the build logs, most likely something to deal with https://github.com/Zulko/moviepy/issues/518, which came up in the recent moviepy release.