### PR TITLE
Making everything store absolute onsets

### DIFF
--- a/pliers/converters/api.py
+++ b/pliers/converters/api.py
@@ -46,7 +46,7 @@ class SpeechRecognitionAPIConverter(AudioToTextConverter, EnvironmentKeyMixin):
 
         text = getattr(self.recognizer, self.recognize_method)(clip, self.api_key)
 
-        return ComplexTextStim(text=text)
+        return ComplexTextStim(text=text, onset=audio.onset)
 
 
 class WitTranscriptionConverter(SpeechRecognitionAPIConverter):
@@ -107,6 +107,8 @@ class IBMSpeechAPIConverter(AudioToTextConverter, EnvironmentKeyMixin):
         self.resolution = resolution
 
     def _convert(self, audio):
+        offset = 0.0 if audio.onset is None else audio.onset
+
         import speech_recognition as sr
 
         with audio.get_filename() as filename:
@@ -128,15 +130,17 @@ class IBMSpeechAPIConverter(AudioToTextConverter, EnvironmentKeyMixin):
                         text = entry[0]
                         start = entry[1]
                         end = entry[2]
-                        elements.append(TextStim(text=text, onset=start,
+                        elements.append(TextStim(text=text,
+                                                 onset=offset+start,
                                                  duration=end-start))
                 elif self.resolution is 'phrases':
                     text = result['alternatives'][0]['transcript']
                     start = timestamps[0][1]
                     end = timestamps[-1][2]
-                    elements.append(TextStim(text=text, onset=start,
+                    elements.append(TextStim(text=text,
+                                             onset=offset+start,
                                              duration=end-start))
-        return ComplexTextStim(elements=elements)
+        return ComplexTextStim(elements=elements, onset=audio.onset)
 
     def _query_api(self, clip):
         # Adapted from SpeechRecognition source code, modified to get text

--- a/pliers/converters/video.py
+++ b/pliers/converters/video.py
@@ -86,7 +86,7 @@ class FrameSamplingConverter(VideoToDerivedVideoConverter):
 
             elem = VideoFrameStim(video=video, frame_num=f, duration=dur)
             offset = 0.0 if video.onset is None else video.onset
-            elem.onset = offset + elem.onset
+            elem.onset = offset + onsets[i]
             frames.append(elem)
 
         return DerivedVideoStim(filename=video.filename,

--- a/pliers/converters/video.py
+++ b/pliers/converters/video.py
@@ -14,7 +14,7 @@ class VideoToAudioConverter(Converter):
     _output_type = AudioStim
 
     def _convert(self, video):
-        return AudioStim(clip=video.clip.audio)
+        return AudioStim(clip=video.clip.audio, onset=video.onset)
 
 
 class VideoToDerivedVideoConverter(Converter):
@@ -85,7 +85,11 @@ class FrameSamplingConverter(VideoToDerivedVideoConverter):
                 dur = (video.n_frames / video.fps) - onsets[i]
 
             elem = VideoFrameStim(video=video, frame_num=f, duration=dur)
+            offset = 0.0 if video.onset is None else video.onset
+            elem.onset = offset + elem.onset
             frames.append(elem)
 
-        return DerivedVideoStim(filename=video.filename, frames=frames,
-                                frame_index=frame_index)
+        return DerivedVideoStim(filename=video.filename,
+                                frames=frames,
+                                frame_index=frame_index,
+                                onset=video.onset)

--- a/pliers/extractors/audio.py
+++ b/pliers/extractors/audio.py
@@ -80,7 +80,8 @@ class STFTAudioExtractor(AudioExtractor):
             self.freq_bins = bins
 
         features = ['%d_%d' % fb for fb in self.freq_bins]
-        index = [tb for tb in time_bins]
+        offset = 0.0 if stim.onset is None else stim.onset
+        index = [tb + offset for tb in time_bins]
         values = np.zeros((len(index), len(features)))
         for i, fb in enumerate(self.freq_bins):
             start, stop = fb

--- a/pliers/stimuli/text.py
+++ b/pliers/stimuli/text.py
@@ -84,6 +84,8 @@ class ComplexTextStim(Stim):
             raise ValueError("At least one of the 'filename', 'elements', or "
                              "text arguments must be specified.")
 
+        super(ComplexTextStim, self).__init__(filename, onset, duration)
+
         self._elements = []
 
         if filename is not None:
@@ -97,8 +99,6 @@ class ComplexTextStim(Stim):
 
         if text is not None:
             self._from_text(text, unit, tokenizer, language)
-
-        super(ComplexTextStim, self).__init__(filename, onset, duration)
 
     @property
     def elements(self):
@@ -123,7 +123,7 @@ class ComplexTextStim(Stim):
                 if duration is None:
                     duration = default_duration
                 elem = TextStim(filename, r['text'], r['onset'], duration)
-            self._elements.append(elem)
+            self.add_elem(elem)
 
     def _from_srt(self, filename):
         import pysrt
@@ -145,7 +145,12 @@ class ComplexTextStim(Stim):
 
         for i, r in df.iterrows():
             elem = TextStim(filename, r['text'], r['onset'], r["duration"])
-            self._elements.append(elem)
+            self.add_elem(elem)
+
+    def add_elem(self, elem):
+        offset = 0.0 if self.onset is None else self.onset
+        elem.onset = offset if elem.onset is None else offset + elem.onset
+        self._elements.append(elem)
 
     def __iter__(self):
         """ Iterate text elements. """
@@ -184,4 +189,4 @@ class ComplexTextStim(Stim):
         # TODO: track order as a separate attribute from duration, because we
         # can't treat serial position as if it were time in seconds.
         for i, t in enumerate(tokens):
-            self._elements.append(TextStim(text=t, onset=None, duration=None))
+            self.add_elem(TextStim(text=t, onset=None, duration=None))

--- a/pliers/stimuli/video.py
+++ b/pliers/stimuli/video.py
@@ -107,8 +107,8 @@ class DerivedVideoStim(VideoStim):
             original VideoStim.
     """
 
-    def __init__(self, filename, frames, frame_index=None):
-        super(DerivedVideoStim, self).__init__(filename)
+    def __init__(self, filename, frames, frame_index=None, onset=None):
+        super(DerivedVideoStim, self).__init__(filename, onset=onset)
         self._frames = frames
         self.frame_index = frame_index
         self.name += '_derived'

--- a/pliers/stimuli/video.py
+++ b/pliers/stimuli/video.py
@@ -27,6 +27,8 @@ class VideoFrameStim(ImageStim):
         spf = 1. / video.fps
         duration = spf if duration is None else duration
         onset = frame_num * spf
+        if video.onset:
+            onset += video.onset
         super(VideoFrameStim, self).__init__(filename, onset, duration, data)
         if data is None:
             self.data = self.video.get_frame(index=frame_num).data

--- a/pliers/tests/test_extractors.py
+++ b/pliers/tests/test_extractors.py
@@ -46,34 +46,37 @@ def test_implicit_stim_iteration():
 
 def test_implicit_stim_conversion():
     image_dir = join(get_test_data_path(), 'image')
-    stim = ImageStim(join(image_dir, 'button.jpg'))
+    stim = ImageStim(join(image_dir, 'button.jpg'), onset=4.2)
     ext = LengthExtractor()
     result = ext.transform(stim).to_df()
     assert 'text_length' in result.columns
     assert result['text_length'][0] == 4
+    assert result['onset'][0] == 4.2
 
 
 @pytest.mark.skipif("'WIT_AI_API_KEY' not in os.environ")
 def test_implicit_stim_conversion2():
     audio_dir = join(get_test_data_path(), 'audio')
-    stim = AudioStim(join(audio_dir, 'homer.wav'))
+    stim = AudioStim(join(audio_dir, 'homer.wav'), onset=4.2)
     ext = LengthExtractor()
     result = ext.transform(stim)
     first_word = result[0].to_df()
     assert 'text_length' in first_word.columns
     assert first_word['text_length'][0] > 0
+    assert first_word['onset'][0] >= 4.2
 
 
 @pytest.mark.skipif("'WIT_AI_API_KEY' not in os.environ")
 def test_implicit_stim_conversion3():
     video_dir = join(get_test_data_path(), 'video')
-    stim = VideoStim(join(video_dir, 'obama_speech.mp4'))
+    stim = VideoStim(join(video_dir, 'obama_speech.mp4'), onset=4.2)
     ext = LengthExtractor()
     result = ext.transform(stim)
     first_word = result[0].to_df()
     # The word should be "today"
     assert 'text_length' in first_word.columns
     assert first_word['text_length'][0] == 5
+    assert first_word['onset'][0] >= 4.2
 
 
 def test_text_extractor():
@@ -89,11 +92,13 @@ def test_text_extractor():
 
 
 def test_text_length_extractor():
-    stim = TextStim(text='hello world')
+    stim = TextStim(text='hello world', onset=4.2, duration=1)
     ext = LengthExtractor()
     result = ext.transform(stim).to_df()
     assert 'text_length' in result.columns
     assert result['text_length'][0] == 11
+    assert result['onset'][0] == 4.2
+    assert result['duration'][0] == 1
 
 
 def test_unique_words_extractor():
@@ -133,12 +138,13 @@ def test_predefined_dictionary_extractor():
 
 def test_stft_extractor():
     audio_dir = join(get_test_data_path(), 'audio')
-    stim = AudioStim(join(audio_dir, 'barber.wav'))
+    stim = AudioStim(join(audio_dir, 'barber.wav'), onset=4.2)
     ext = STFTAudioExtractor(frame_size=1., spectrogram=False,
                              freq_bins=[(100, 300), (300, 3000), (3000, 20000)])
     result = ext.transform(stim)
     df = result.to_df()
     assert df.shape == (557, 5)
+    assert df['onset'][0] == 4.2
 
 
 def test_mean_amplitude_extractor():
@@ -163,27 +169,33 @@ def test_part_of_speech_extractor():
 
 def test_brightness_extractor():
     image_dir = join(get_test_data_path(), 'image')
-    stim = ImageStim(join(image_dir, 'apple.jpg'))
+    stim = ImageStim(join(image_dir, 'apple.jpg'), onset=4.2, duration=1)
     result = BrightnessExtractor().transform(stim).to_df()
     brightness = result['brightness'][0]
     assert np.isclose(brightness, 0.88784294, 1e-5)
+    assert result['onset'][0] == 4.2
+    assert result['duration'][0] == 1
 
 
 def test_sharpness_extractor():
     pytest.importorskip('cv2')
     image_dir = join(get_test_data_path(), 'image')
-    stim = ImageStim(join(image_dir, 'apple.jpg'))
+    stim = ImageStim(join(image_dir, 'apple.jpg'), onset=4.2, duration=1)
     result = SharpnessExtractor().transform(stim).to_df()
     sharpness = result['sharpness'][0]
     assert np.isclose(sharpness, 1.0, 1e-5)
+    assert result['onset'][0] == 4.2
+    assert result['duration'][0] == 1
 
 
 def test_vibrance_extractor():
     image_dir = join(get_test_data_path(), 'image')
-    stim = ImageStim(join(image_dir, 'apple.jpg'))
+    stim = ImageStim(join(image_dir, 'apple.jpg'), onset=4.2, duration=1)
     result = VibranceExtractor().transform(stim).to_df()
     color = result['vibrance'][0]
     assert np.isclose(color, 1370.65482988, 1e-5)
+    assert result['onset'][0] == 4.2
+    assert result['duration'][0] == 1
 
 
 def test_saliency_extractor():
@@ -200,9 +212,9 @@ def test_saliency_extractor():
 def test_optical_flow_extractor():
     pytest.importorskip('cv2')
     video_dir = join(get_test_data_path(), 'video')
-    stim = VideoStim(join(video_dir, 'small.mp4'))
+    stim = VideoStim(join(video_dir, 'small.mp4'), onset=4.2)
     result = DenseOpticalFlowExtractor().transform(stim).to_df()
-    target = result.query('onset==3.0')['total_flow']
+    target = result.query('onset==7.2')['total_flow']
     # Value returned by cv2 seems to change over versions, so use low precision
     assert np.isclose(target, 86248.05, 1e-4)
 
@@ -215,7 +227,7 @@ def test_indico_api_text_extractor():
 
     # With ComplexTextStim input
     srtfile = join(get_test_data_path(), 'text', 'wonderful.srt')
-    srt_stim = ComplexTextStim(srtfile)
+    srt_stim = ComplexTextStim(srtfile, onset=4.2)
     result = ext.transform(srt_stim).to_df()
     outdfKeysCheck = set([
         'onset',
@@ -230,6 +242,7 @@ def test_indico_api_text_extractor():
         'personality_agreeableness',
         'personality_conscientiousness'])
     assert set(result.columns) == outdfKeysCheck
+    assert result['onset'][1] == 92.622
 
     # With TextStim input
     ts = TextStim(text="It's a wonderful life.")
@@ -265,6 +278,7 @@ def test_indico_api_image_extractor():
     result2 = ext.transform(stim2).to_df()
     assert set(result2.columns) == outdfKeysCheck
     assert result2['fer_Happy'][0] > 0.7
+
 
 @pytest.mark.skipif("'CLARIFAI_APP_ID' not in os.environ")
 def test_clarifai_api_extractor():
@@ -349,7 +363,7 @@ def test_merge_extractor_results_flattened():
 def test_tensor_flow_inception_v3_extractor():
     image_dir = join(get_test_data_path(), 'image')
     imgs = [join(image_dir, f) for f in ['apple.jpg', 'obama.jpg']]
-    imgs = [ImageStim(im) for im in imgs]
+    imgs = [ImageStim(im, onset=4.2, duration=1) for im in imgs]
     ext = TensorFlowInceptionV3Extractor()
     results = ext.transform(imgs)
     df = merge_results(results)
@@ -358,3 +372,5 @@ def test_tensor_flow_inception_v3_extractor():
         ('TensorFlowInceptionV3Extractor', 'label_1')] == 'Granny Smith'
     assert df.iloc[1][
         ('TensorFlowInceptionV3Extractor', 'score_2')] == '0.22610'
+    assert df[('onset', '')][0] == 4.2
+    assert df[('duration', '')][1] == 1

--- a/pliers/tests/test_stims.py
+++ b/pliers/tests/test_stims.py
@@ -57,7 +57,7 @@ def test_image_stim(dummy_iter_extractor):
 def test_video_stim():
     ''' Test VideoStim functionality. '''
     filename = join(get_test_data_path(), 'video', 'small.mp4')
-    video = VideoStim(filename)
+    video = VideoStim(filename, onset=4.2)
     assert video.fps == 30
     assert video.n_frames in (167, 168)
     assert video.width == 560
@@ -74,6 +74,7 @@ def test_video_stim():
     f2 = video.get_frame(index=100)
     assert isinstance(f2, VideoFrameStim)
     assert isinstance(f2.onset, float)
+    assert f2.onset > 4.2
     f2.data.shape == (320, 560, 3)
 
 
@@ -98,6 +99,9 @@ def test_complex_text_stim():
     assert len(stim.elements) == 4
     assert stim.elements[2].onset == 34
     assert stim.elements[2].duration == 0.2
+    stim = ComplexTextStim(join(text_dir, 'complex_stim_no_header.txt'),
+                           columns='ot', default_duration=0.2, onset=4.2)
+    assert stim.elements[2].onset == 38.2
     stim = ComplexTextStim(join(text_dir, 'complex_stim_with_header.txt'))
     assert len(stim.elements) == 4
     assert stim.elements[2].duration == 0.1


### PR DESCRIPTION
In order to resolve #161 I just made sure each `stim` object always holds its absolute onset, propagated through conversion and extraction. I added several tests for this capability, but more might be necessary. This will require all future converters to make sure the absolute onset is used for resultant stimuli.