### PR TITLE
Stimuli uniqueness

### DIFF
--- a/pliers/extractors/base.py
+++ b/pliers/extractors/base.py
@@ -132,7 +132,7 @@ class ExtractorResult(object):
 
         result.insert(0, 'class', results[0].stim.__class__.__name__)
         result.insert(0, 'filename', results[0].stim.filename)
-        result.insert(0, 'history', str(results[0].history))
+        result.insert(0, 'history', str(results[0].stim.history))
 
         if stim_names:
             result.insert(0, 'stim_name', list(stims)[0])

--- a/pliers/extractors/base.py
+++ b/pliers/extractors/base.py
@@ -166,7 +166,7 @@ def merge_results(results, **merge_feature_args):
     stims = defaultdict(list)
 
     for r in results:
-        stims[id(r.stim)].append(r)
+        stims[hash(r.stim)].append(r)
 
     # First concatenate all features separately for each Stim
     for k, v in stims.items():

--- a/pliers/stimuli/base.py
+++ b/pliers/stimuli/base.py
@@ -64,7 +64,7 @@ class Stim(with_metaclass(ABCMeta)):
         self._history = history
 
     def __hash__(self):
-        return hash((self.filename, self.name, self.onset, self.duration, id(self)))
+        return hash((self.filename, self.name, self.onset, self.duration, self.history))
 
 
 def _get_stim_class(name):

--- a/pliers/tests/test_extractors.py
+++ b/pliers/tests/test_extractors.py
@@ -355,7 +355,7 @@ def test_tensor_flow_inception_v3_extractor():
     results = ext.transform(imgs)
     df = merge_results(results)
     assert len(df) == 2
-    assert df.iloc[0][
-        ('TensorFlowInceptionV3Extractor', 'label_1')] == 'Granny Smith'
-    assert df.iloc[1][
-        ('TensorFlowInceptionV3Extractor', 'score_2')] == '0.22610'
+    assert 'Granny Smith' in df[
+        ('TensorFlowInceptionV3Extractor', 'label_1')].values
+    assert '0.22610' in df[
+        ('TensorFlowInceptionV3Extractor', 'score_2')].values

--- a/pliers/tests/test_extractors.py
+++ b/pliers/tests/test_extractors.py
@@ -211,7 +211,7 @@ def test_optical_flow_extractor():
 def test_indico_api_text_extractor():
 
     ext = IndicoAPITextExtractor(api_key=os.environ['INDICO_APP_KEY'],
-                             models=['emotion', 'personality'])
+                                 models=['emotion', 'personality'])
 
     # With ComplexTextStim input
     srtfile = join(get_test_data_path(), 'text', 'wonderful.srt')
@@ -242,7 +242,7 @@ def test_indico_api_text_extractor():
 def test_indico_api_image_extractor():
 
     ext = IndicoAPIImageExtractor(api_key=os.environ['INDICO_APP_KEY'],
-                             models=['fer', 'content_filtering'])
+                                  models=['fer', 'content_filtering'])
 
     image_dir = join(get_test_data_path(), 'image')
     stim1 = ImageStim(join(image_dir, 'apple.jpg'))
@@ -266,6 +266,7 @@ def test_indico_api_image_extractor():
     assert set(result2.columns) == outdfKeysCheck
     assert result2['fer_Happy'][0] > 0.7
 
+
 @pytest.mark.skipif("'CLARIFAI_APP_ID' not in os.environ")
 def test_clarifai_api_extractor():
     image_dir = join(get_test_data_path(), 'image')
@@ -285,9 +286,9 @@ def test_merge_extractor_results_by_features():
     results = [e.transform(stim) for e in extractors]
     df = ExtractorResult.merge_features(results)
 
-    de = DummyExtractor()
     de_names = ['Extractor1', 'Extractor2', 'Extractor3']
-    results = [de.transform(stim, name) for name in de_names]
+    des = [DummyExtractor(name=name) for name in de_names]
+    results = [de.transform(stim) for de in des]
     df = ExtractorResult.merge_features(results)
     assert df.shape == (177, 16)
     assert df.columns.levels[1].unique().tolist() == [0, 1, 2, '']
@@ -314,12 +315,12 @@ def test_merge_extractor_results():
     image_dir = join(get_test_data_path(), 'image')
     stim1 = ImageStim(join(image_dir, 'apple.jpg'))
     stim2 = ImageStim(join(image_dir, 'obama.jpg'))
-    de = DummyExtractor()
     de_names = ['Extractor1', 'Extractor2', 'Extractor3']
-    results = [de.transform(stim1, name) for name in de_names]
-    results += [de.transform(stim2, name) for name in de_names]
+    des = [DummyExtractor(name=name) for name in de_names]
+    results = [de.transform(stim1) for de in des]
+    results += [de.transform(stim2) for de in des]
     df = merge_results(results)
-    assert df.shape == (355, 16)
+    assert df.shape == (354, 16)
     cols = ['onset', 'duration', 'class', 'filename', 'history', 'stim_name',
             'source_file']
     assert df.columns.levels[0].unique().tolist() == de_names + cols
@@ -332,15 +333,15 @@ def test_merge_extractor_results_flattened():
     image_dir = join(get_test_data_path(), 'image')
     stim1 = ImageStim(join(image_dir, 'apple.jpg'))
     stim2 = ImageStim(join(image_dir, 'obama.jpg'))
-    de = DummyExtractor()
     de_names = ['Extractor1', 'Extractor2', 'Extractor3']
-    results = [de.transform(stim1, name) for name in de_names]
-    results += [de.transform(stim2, name) for name in de_names]
+    des = [DummyExtractor(name=name) for name in de_names]
+    results = [de.transform(stim1) for de in des]
+    results += [de.transform(stim2) for de in des]
     df = merge_results(results, flatten_columns=True)
     de_cols = ['Extractor1_0', 'Extractor1_1', 'Extractor1_2',
                'Extractor2_0', 'Extractor2_1', 'Extractor2_2',
                'Extractor3_0', 'Extractor3_1', 'Extractor3_2']
-    assert df.shape == (355, 16)
+    assert df.shape == (354, 16)
     cols = ['onset', 'class', 'filename', 'history', 'stim_name', 'duration',
             'source_file']
     assert set(df.columns.unique().tolist()) == set(cols + de_cols)

--- a/pliers/tests/test_graph.py
+++ b/pliers/tests/test_graph.py
@@ -92,7 +92,6 @@ def test_small_pipeline2():
     history = result[0].history.to_df()
     assert history.shape == (1, 8)
     result = merge_results(result)
-    print result
     assert ('BrightnessExtractor', 'brightness') in result.columns
     brightness = result[('BrightnessExtractor', 'brightness')].values[0]
     vibrance = result[('VibranceExtractor', 'vibrance')].values[0]

--- a/pliers/tests/test_graph.py
+++ b/pliers/tests/test_graph.py
@@ -8,6 +8,7 @@ from pliers.stimuli import (ImageStim, VideoStim)
 from .utils import get_test_data_path, DummyExtractor
 from os.path import join, exists
 from numpy.testing import assert_almost_equal
+import numpy as np
 import tempfile
 import os
 
@@ -81,6 +82,23 @@ def test_small_pipeline():
     assert (0, 'text[Exit]') in result['stim_name'].values
     assert ('LengthExtractor', 'text_length') in result.columns
     assert result[('LengthExtractor', 'text_length')].values[0] == 4
+
+
+def test_small_pipeline2():
+    filename = join(get_test_data_path(), 'image', 'button.jpg')
+    nodes = [BrightnessExtractor(), VibranceExtractor()]
+    graph = Graph(nodes)
+    result = list(graph.run([filename], merge=False))
+    history = result[0].history.to_df()
+    assert history.shape == (1, 8)
+    result = merge_results(result)
+    print result
+    assert ('BrightnessExtractor', 'brightness') in result.columns
+    brightness = result[('BrightnessExtractor', 'brightness')].values[0]
+    vibrance = result[('VibranceExtractor', 'vibrance')].values[0]
+    assert_almost_equal(brightness, 0.746965, 5)
+    assert ('VibranceExtractor', 'vibrance') in result.columns
+    assert_almost_equal(vibrance, 841.577274, 5)
 
 
 def test_small_pipeline_json_spec():

--- a/pliers/tests/utils.py
+++ b/pliers/tests/utils.py
@@ -18,14 +18,17 @@ class DummyExtractor(Extractor):
     _input_type = ImageStim
     _log_attributes = ('param_A', 'param_B')
 
-    def __init__(self, param_A=None, param_B='pie'):
+    def __init__(self, param_A=None, param_B='pie', name=None, n_rows=100,
+                 n_cols=3, max_time=1000):
         super(DummyExtractor, self).__init__()
         self.param_A = param_A
         self.param_B = param_B
-
-    def _extract(self, stim, name=None, n_rows=100, n_cols=3, max_time=1000):
-        data = np.random.randint(0, 1000, (n_rows, n_cols))
-        onsets = np.random.choice(n_rows*2, n_rows, False)
         if name is not None:
             self.name = name
+        self.n_rows = n_rows
+        self.n_cols = n_cols
+
+    def _extract(self, stim):
+        data = np.random.randint(0, 1000, (self.n_rows, self.n_cols))
+        onsets = np.random.choice(self.n_rows*2, self.n_rows, False)
         return ExtractorResult(data, stim, deepcopy(self), onsets=onsets)


### PR DESCRIPTION
Resolves #172 . Additionally added test to make sure the error doesn't come up again.

No longer using stim id to hash, instead added the stim's history in the hash calculation. We *think* this captures true stim equality/uniqueness.

Modified the `DummyExtractor` in `utils.py` for tests to use proper `Extractor` convention, and prevent corresponding test failures.

