### PR TITLE
Extraction metadata management

### DIFF
--- a/pliers/extractors/base.py
+++ b/pliers/extractors/base.py
@@ -130,9 +130,8 @@ class ExtractorResult(object):
                              "onsets and have the same number of rows. It is "
                              "not possible to merge mismatched instances.")
 
-        if metadata:
-            extra_columns.remove('onset')
-        else:
+        extra_columns.remove('onset')
+        if not metadata:
             extra_columns = ['duration']
         for col in extra_columns:
             result.insert(0, col, dfs[0][col][0])

--- a/pliers/extractors/base.py
+++ b/pliers/extractors/base.py
@@ -59,14 +59,18 @@ class ExtractorResult(object):
             durations = stim.duration
         self.durations = durations if durations is not None else np.nan
 
-    def to_df(self, stim_name=False):
+    def to_df(self, metadata=False):
         df = pd.DataFrame(self.data)
         if self.features is not None:
             df.columns = self.features
         df.insert(0, 'duration', self.durations)
         df.insert(0, 'onset', self.onsets)
-        if stim_name:
+        if metadata:
             df['stim_name'] = self.stim.name
+            df['class'] = self.stim.__class__.__name__
+            df['filename'] = self.stim.filename
+            df['history'] = str(self.stim.history)
+            df['source_file'] = self.history.to_df().iloc[0].source_file
         return df
 
     @property
@@ -78,8 +82,8 @@ class ExtractorResult(object):
         self._history = history
 
     @classmethod
-    def merge_features(cls, results, extractor_names=True, stim_names=True,
-                       source_files=True, flatten_columns=False):
+    def merge_features(cls, results, metadata=True, extractor_names=True,
+                       flatten_columns=False):
         ''' Merge a list of ExtractorResults bound to the same Stim into a
         single DataFrame.
 
@@ -87,10 +91,7 @@ class ExtractorResult(object):
             results (list, tuple): A list of ExtractorResult instances to merge
             extractor_names (bool): if True, stores the associated Extractor
                 names in the top level of the column MultiIndex.
-            stim_names (bool): if True, stores the associated Stim names in the
-                top level of the row MultiIndex.
-            source_files (bool): if True, stores the full path of the stimuli
-                on disk in a new column.
+            metadata (bool): if True, stores all ExtractorResult metadata
             flatten_columns (bool): if True, flattens the resultant column
                 MultiIndex such that feature columns are in the format
                 <extractor class>_<feature name>
@@ -98,12 +99,14 @@ class ExtractorResult(object):
 
         # Make sure all ExtractorResults are associated with same Stim.
         stims = set([r.stim.name for r in results])
-        dfs = [r.to_df() for r in results]
+        dfs = [r.to_df(metadata=metadata) for r in results]
         if len(stims) > 1:
             raise ValueError("merge_features() can only be called on a set of "
                              "ExtractorResults associated with the same Stim.")
 
         keys = [r.extractor.name for r in results] if extractor_names else None
+        extra_columns = ['onset', 'duration', 'class', 'filename', 'history',
+                         'stim_name', 'source_file']
 
         # If onsets are all NaN
         if all([r['onset'].isnull().all() for r in dfs]):
@@ -111,14 +114,15 @@ class ExtractorResult(object):
                 raise ValueError("If ExtractorResults do not specify onsets, "
                                  "all ExtractorResults to merge must have "
                                  "identical numbers of rows.")
-            dfs = [r.drop(['onset'], axis=1) for r in dfs]
-            result = pd.concat(dfs, axis=1, keys=keys)
+            feature_dfs = [r.drop(extra_columns, axis=1) for r in dfs]
+            result = pd.concat(feature_dfs, axis=1, keys=keys)
             result.insert(0, 'onset', np.nan)
 
         # If onsets are specified
         elif all([r['onset'].notnull().all() for r in dfs]):
-            dfs = [r.set_index('onset').sort_index() for r in dfs]
-            result = pd.concat(dfs, axis=1, keys=keys).reset_index()
+            feature_dfs = [r.set_index('onset').sort_index() for r in dfs]
+            feature_dfs = [r.drop(extra_columns, axis=1, errors='ignore') for r in feature_dfs]
+            result = pd.concat(feature_dfs, axis=1, keys=keys).reset_index()
 
         else:
             raise ValueError("To merge a list of ExtractorResults, all "
@@ -126,19 +130,12 @@ class ExtractorResult(object):
                              "onsets and have the same number of rows. It is "
                              "not possible to merge mismatched instances.")
 
-        result = result.drop('duration', axis=1, level=1)
-        result.columns = pd.MultiIndex.from_tuples(result.columns.values)
-        result.insert(0, 'duration', results[0].durations)
-
-        result.insert(0, 'class', results[0].stim.__class__.__name__)
-        result.insert(0, 'filename', results[0].stim.filename)
-        result.insert(0, 'history', str(results[0].stim.history))
-
-        if stim_names:
-            result.insert(0, 'stim_name', list(stims)[0])
-
-        if source_files:
-            result.insert(0, 'source_file', results[0].history.to_df().iloc[0].source_file)
+        if metadata:
+            extra_columns.remove('onset')
+        else:
+            extra_columns = ['duration']
+        for col in extra_columns:
+            result.insert(0, col, dfs[0][col][0])
 
         result = result.sort_values(['onset']).reset_index(drop=True)
         if flatten_columns:
@@ -147,7 +144,7 @@ class ExtractorResult(object):
 
     @classmethod
     def merge_stims(cls, results):
-        results = [r.to_df(True) if isinstance(
+        results = [r.to_df(metadata=True) if isinstance(
             r, ExtractorResult) else r for r in results]
         return pd.concat(results, axis=0).sort_values('onset').reset_index(drop=True)
 

--- a/pliers/tests/test_extractors.py
+++ b/pliers/tests/test_extractors.py
@@ -317,9 +317,10 @@ def test_merge_extractor_results_by_stims():
     de = DummyExtractor()
     results = [de.transform(stim1), de.transform(stim2)]
     df = ExtractorResult.merge_stims(results)
-    assert df.shape == (200, 6)
+    assert df.shape == (200, 10)
     assert set(df.columns.tolist()) == set(
-        ['onset', 'duration', 0, 1, 2, 'stim_name'])
+        ['onset', 'duration', 0, 1, 2, 'stim_name', 'class', 'filename',
+         'history', 'source_file'])
     assert set(df['stim_name'].unique()) == set(['obama.jpg', 'apple.jpg'])
 
 


### PR DESCRIPTION
Refactored the way extraction metadata gets added. Now a single `ExtractorResult` will can have that data when `to_df` is called (Resolves #164). Also made the metadata management in `merge_features` a bit more straightforward.
