### PR TITLE
Minor cleanup and improvements

### DIFF
--- a/pliers/extractors/api.py
+++ b/pliers/extractors/api.py
@@ -11,6 +11,7 @@ from pliers.extractors.image import ImageExtractor
 from pliers.extractors.text import TextExtractor
 from pliers.extractors.base import Extractor, ExtractorResult
 from pliers.transformers import BatchTransformerMixin, EnvironmentKeyMixin
+from pliers.utils import listify
 
 
 try:
@@ -158,6 +159,7 @@ class ClarifaiAPIExtractor(BatchTransformerMixin, ImageExtractor,
         self.max_concepts = max_concepts
         self.select_concepts = select_concepts
         if select_concepts:
+            select_concepts = listify(select_concepts)
             self.select_concepts = [Concept(concept_name=n) for n in select_concepts]
 
     def _extract(self, stims):

--- a/pliers/extractors/api.py
+++ b/pliers/extractors/api.py
@@ -17,7 +17,8 @@ try:
     from clarifai.rest.client import (ClarifaiApp,
                                       ModelOutputConfig,
                                       ModelOutputInfo,
-                                      Image)
+                                      Image,
+                                      Concept)
 except ImportError:
     pass
 
@@ -156,6 +157,8 @@ class ClarifaiAPIExtractor(BatchTransformerMixin, ImageExtractor,
         self.min_value = min_value
         self.max_concepts = max_concepts
         self.select_concepts = select_concepts
+        if select_concepts:
+            self.select_concepts = [Concept(concept_name=n) for n in select_concepts]
 
     def _extract(self, stims):
         output_config = ModelOutputConfig(min_value=self.min_value,

--- a/pliers/extractors/api.py
+++ b/pliers/extractors/api.py
@@ -125,8 +125,12 @@ class ClarifaiAPIExtractor(BatchTransformerMixin, ImageExtractor,
             to be passed the first time the extractor is initialized.
         model (str): The name of the Clarifai model to use. If None, defaults
             to the general image tagger.
-        select_classes (list): List of classes (strings) to query from the API.
-            For example, ['food', 'animal'].
+        min_value (float): A value between 0.0 and 1.0 indicating the minimum
+            confidence required to return a prediction. Defaults to 0.0.
+        max_concepts (int): A value between 0 and 200 indicating the maximum
+            number of label predictions returned.
+        select_concepts (list): List of concepts (strings) to query from the
+            API. For example, ['food', 'animal'].
     '''
 
     _log_attributes = ('model', 'min_value', 'max_concepts', 'select_concepts')

--- a/pliers/extractors/api.py
+++ b/pliers/extractors/api.py
@@ -137,7 +137,7 @@ class ClarifaiAPIExtractor(BatchTransformerMixin, ImageExtractor,
                  min_value=None,
                  max_concepts=None,
                  select_concepts=None):
-        ImageExtractor.__init__(self)
+        super(ClarifaiAPIExtractor, self).__init__()
         if app_id is None or app_secret is None:
             try:
                 app_id = os.environ['CLARIFAI_APP_ID']

--- a/pliers/extractors/api.py
+++ b/pliers/extractors/api.py
@@ -10,7 +10,7 @@ except:
 from pliers.extractors.image import ImageExtractor
 from pliers.extractors.text import TextExtractor
 from pliers.extractors.base import Extractor, ExtractorResult
-from pliers.transformers import BatchTransformerMixin
+from pliers.transformers import BatchTransformerMixin, EnvironmentKeyMixin
 
 
 try:
@@ -27,7 +27,8 @@ except ImportError:
     pass
 
 
-class IndicoAPIExtractor(BatchTransformerMixin, Extractor):
+class IndicoAPIExtractor(BatchTransformerMixin, Extractor,
+                         EnvironmentKeyMixin):
 
     ''' Base class for all Indico API Extractors
 
@@ -40,6 +41,7 @@ class IndicoAPIExtractor(BatchTransformerMixin, Extractor):
     _log_attributes = ('models',)
     _input_type = ()
     _batch_size = 20
+    _env_keys = 'INDICO_APP_KEY'
 
     def __init__(self, api_key=None, models=None):
         super(IndicoAPIExtractor, self).__init__()
@@ -112,7 +114,8 @@ class IndicoAPIImageExtractor(ImageExtractor, IndicoAPIExtractor):
         super(IndicoAPIImageExtractor, self).__init__(**kwargs)
 
 
-class ClarifaiAPIExtractor(BatchTransformerMixin, ImageExtractor):
+class ClarifaiAPIExtractor(BatchTransformerMixin, ImageExtractor,
+                           EnvironmentKeyMixin):
 
     ''' Uses the Clarifai API to extract tags of images.
     Args:
@@ -128,6 +131,7 @@ class ClarifaiAPIExtractor(BatchTransformerMixin, ImageExtractor):
 
     _log_attributes = ('model', 'min_value', 'max_concepts', 'select_concepts')
     _batch_size = 128
+    _env_keys = ('CLARIFAI_APP_ID', 'CLARIFAI_APP_SECRET')
 
     def __init__(self, app_id=None, app_secret=None, model='general-v1.3',
                  min_value=None,

--- a/pliers/extractors/models.py
+++ b/pliers/extractors/models.py
@@ -24,6 +24,8 @@ class TensorFlowInceptionV3Extractor(ImageExtractor):
             each image.
      '''
 
+    log_attributes = ('model_dir', 'data_url', 'num_predictions')
+
     def __init__(self, model_dir=None, data_url=None, num_predictions=5):
 
         super(TensorFlowInceptionV3Extractor, self).__init__()

--- a/pliers/extractors/models.py
+++ b/pliers/extractors/models.py
@@ -24,7 +24,7 @@ class TensorFlowInceptionV3Extractor(ImageExtractor):
             each image.
      '''
 
-    log_attributes = ('model_dir', 'data_url', 'num_predictions')
+    _log_attributes = ('model_dir', 'data_url', 'num_predictions')
 
     def __init__(self, model_dir=None, data_url=None, num_predictions=5):
 

--- a/pliers/extractors/models.py
+++ b/pliers/extractors/models.py
@@ -77,8 +77,8 @@ class TensorFlowInceptionV3Extractor(ImageExtractor):
         values, features = [], []
         for i, h in enumerate(hits):
             m = re.search('(.*?)\s\(score\s\=\s([0-9\.]+)\)', h.strip())
-            values.extend(m.groups())
-            ind = i + 1
-            features.extend(['label_%d' % ind, 'score_%d' % ind])
+            extraction = m.groups()
+            features.append(extraction[0])
+            values.append(float(extraction[1]))
 
         return ExtractorResult([values], stim, self, features=features)

--- a/pliers/filters/text.py
+++ b/pliers/filters/text.py
@@ -36,6 +36,8 @@ class WordStemmingFilter(TextFilter):
         'rslp': 'RSLPStemmer'
     }
 
+    _log_attributes = ('stemmer',)
+
     def __init__(self, stemmer='porter', *args, **kwargs):
 
         if isinstance(stemmer, string_types):

--- a/pliers/filters/text.py
+++ b/pliers/filters/text.py
@@ -32,7 +32,6 @@ class WordStemmingFilter(TextFilter):
         'lancaster': 'LancasterStemmer',
         'isri': 'ISRIStemmer',
         'regexp': 'RegexpStemmer',
-        'wordnet': 'WordNetLemmatizer',
         'rslp': 'RSLPStemmer'
     }
 

--- a/pliers/stimuli/audio.py
+++ b/pliers/stimuli/audio.py
@@ -6,7 +6,7 @@ from moviepy.audio.io.AudioFileClip import AudioFileClip
 
 class AudioStim(Stim):
 
-    ''' Represents an audio clip. For now, only handles wav files.
+    ''' Represents an audio clip.
     Args:
         filename (str): Path to audio file.
         onset (float): Optional onset of the audio file (in seconds) with

--- a/pliers/tests/test_extractors.py
+++ b/pliers/tests/test_extractors.py
@@ -297,11 +297,17 @@ def test_clarifai_api_extractor():
     assert result['apple'][0] > 0.5
     assert result.ix[:, 5][0] > 0.0
 
-    # Make sure extractor knows how to use temp files
-    stim2 = ImageStim(data=stim.data)
-    result = ClarifaiAPIExtractor().transform(stim2).to_df()
-    assert result['apple'][0] > 0.5
-    assert result.ix[:, 5][0] > 0.0
+    result = ClarifaiAPIExtractor(max_concepts=5).transform(stim).to_df()
+    assert result.shape == (1, 7)
+
+    result = ClarifaiAPIExtractor(min_value=0.9).transform(stim).to_df()
+    assert all(np.isnan(d) or d > 0.9 for d in result.values[0])
+
+    concepts = ['cat', 'dog']
+    result = ClarifaiAPIExtractor(select_concepts=concepts).transform(stim)
+    result = result.to_df()
+    assert result.shape == (1, 4)
+    assert 'cat' in result.columns and 'dog' in result.columns
 
 
 @pytest.mark.skipif("'CLARIFAI_APP_ID' not in os.environ")

--- a/pliers/tests/test_extractors.py
+++ b/pliers/tests/test_extractors.py
@@ -401,9 +401,8 @@ def test_tensor_flow_inception_v3_extractor():
     results = ext.transform(imgs)
     df = merge_results(results)
     assert len(df) == 2
-    assert 'Granny Smith' in df[
-        ('TensorFlowInceptionV3Extractor', 'label_1')].values
-    assert '0.22610' in df[
-        ('TensorFlowInceptionV3Extractor', 'score_2')].values
+    assert ('TensorFlowInceptionV3Extractor', 'Granny Smith') in df.columns
+    assert 0.22610 in df[
+        ('TensorFlowInceptionV3Extractor', 'Windsor tie')].values
     assert 4.2 in df[('onset', '')].values
     assert 1 in df[('duration', '')].values

--- a/pliers/tests/test_filters.py
+++ b/pliers/tests/test_filters.py
@@ -29,7 +29,7 @@ def test_word_stemming_filter():
     assert stems == target
 
     # Handles StemmerI stemmer
-    stemmer = nls.WordNetLemmatizer()
+    stemmer = nls.SnowballStemmer(language='english')
     filt = WordStemmingFilter(stemmer=stemmer)
     stemmed = filt.transform(stim)
     stems = [s.text for s in stemmed]


### PR DESCRIPTION
- Went through and made sure all `_log_attributes` were correct
- Went through and made all appropriate `Transformers` inherit the `EnvironmentKeyMixin`
- Upgraded the `ClarifaiAPIExtractor` to use v2 of the API
- Adjusted `TensorFlowInceptionV3Extractor` to output in the same format as other object recognition extractors, i.e. using objects as columns instead of the `label_1` `score_1` format
- Fixed bug in stemming filter by removing the `WordNetLemmatizer` since it does not have a `.stem` method