### PR TITLE
Twitter Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ install:
 - pip install --upgrade --ignore-installed setuptools
 - pip install python-magic coveralls pytest-cov pysrt xlrd clarifai pytesseract
 - pip install moviepy==0.2.2.13
-- pip install SpeechRecognition IndicoIo pygraphviz sklearn
+- pip install SpeechRecognition IndicoIo pygraphviz sklearn python-twitter
 
 before_script:
   - python -m pliers.support.download

--- a/optional-dependencies.txt
+++ b/optional-dependencies.txt
@@ -11,3 +11,4 @@ pytesseract
 IndicoIo
 tensorflow>=1.0.0
 scikit-learn
+python-twitter

--- a/pliers/stimuli/__init__.py
+++ b/pliers/stimuli/__init__.py
@@ -1,6 +1,7 @@
 ''' Stim hierarchy. '''
 
 from .base import load_stims
+from .api import TweetStim
 from .audio import AudioStim
 from .compound import CompoundStim, TranscribedAudioCompoundStim
 from .image import ImageStim
@@ -18,5 +19,6 @@ __all__ = [
     'VideoStim',
     'DerivedVideoStim',
     'VideoFrameStim',
+    'TweetStim',
     'load_stims'
 ]

--- a/pliers/stimuli/__init__.py
+++ b/pliers/stimuli/__init__.py
@@ -1,7 +1,7 @@
 ''' Stim hierarchy. '''
 
 from .base import load_stims
-from .api import TweetStim
+from .api import TweetStim, TweetStimFactory
 from .audio import AudioStim
 from .compound import CompoundStim, TranscribedAudioCompoundStim
 from .image import ImageStim
@@ -19,6 +19,7 @@ __all__ = [
     'VideoStim',
     'DerivedVideoStim',
     'VideoFrameStim',
+    'TweetStimFactory'
     'TweetStim',
     'load_stims'
 ]

--- a/pliers/stimuli/api.py
+++ b/pliers/stimuli/api.py
@@ -1,0 +1,45 @@
+import os
+
+from .base import load_stims
+from .compound import CompoundStim
+from .image import ImageStim
+from .text import TextStim
+from .video import VideoStim
+from pliers.transformers import EnvironmentKeyMixin
+
+
+class TweetStim(CompoundStim, EnvironmentKeyMixin):
+
+    _allowed_types = (TextStim, ImageStim, VideoStim)
+    _allow_multiple = True
+    _primary = TextStim
+    _env_keys = ('TWITTER_CONSUMER_KEY', 'TWITTER_CONSUMER_SECRET',
+                 'TWITTER_ACCESS_TOKEN_KEY', 'TWITTER_ACCESS_TOKEN_SECRET')
+
+    def __init__(self, consumer_key=None, consumer_secret=None,
+                 access_token_key=None, access_token_secret=None,
+                 status_id=None):
+        import twitter
+
+        if consumer_key is None or consumer_secret is None or \
+           access_token_key is None or access_token_secret is None:
+            try:
+                consumer_key = os.environ['TWITTER_CONSUMER_KEY']
+                consumer_secret = os.environ['TWITTER_CONSUMER_SECRET']
+                access_token_key = os.environ['TWITTER_ACCESS_TOKEN_KEY']
+                access_token_secret = os.environ['TWITTER_ACCESS_TOKEN_SECRET']
+            except KeyError:
+                raise ValueError("Valid Twitter API credentials "
+                                 "must be passed the first time a TweetStim "
+                                 "is initialized.")
+
+        self.api = twitter.Api(consumer_key=consumer_key,
+                               consumer_secret=consumer_secret,
+                               access_token_key=access_token_key,
+                               access_token_secret=access_token_secret)
+        self.api.VerifyCredentials()
+        self.status = self.api.GetStatus(status_id)
+        elements = [TextStim(text=self.status.text)]
+        if self.status.media:
+            elements.extend(load_stims([m.url for m in self.status.media]))
+        super(TweetStim, self).__init__(elements=elements)

--- a/pliers/stimuli/api.py
+++ b/pliers/stimuli/api.py
@@ -41,5 +41,6 @@ class TweetStim(CompoundStim, EnvironmentKeyMixin):
         self.status = self.api.GetStatus(status_id)
         elements = [TextStim(text=self.status.text)]
         if self.status.media:
-            elements.extend(load_stims([m.url for m in self.status.media]))
+            media_stims = load_stims([m.media_url for m in self.status.media])
+            elements.extend(media_stims)
         super(TweetStim, self).__init__(elements=elements)

--- a/pliers/stimuli/api.py
+++ b/pliers/stimuli/api.py
@@ -8,17 +8,27 @@ from .video import VideoStim
 from pliers.transformers import EnvironmentKeyMixin
 
 
-class TweetStim(CompoundStim, EnvironmentKeyMixin):
+class TweetFactory(EnvironmentKeyMixin):
 
-    _allowed_types = (TextStim, ImageStim, VideoStim)
-    _allow_multiple = True
-    _primary = TextStim
+    '''
+    An object from which to generate TweetStims, creates an Api instance from
+    the python-twitter library
+
+    Args:
+        consumer_key (str): A valid consumer key for the Twitter API
+        consumer_secret (str): A valid consumer secret key for the Twitter API
+        access_token_key (str): A valid access token for the Twitter API
+        access_token_secret (str): A valid access token secret for the
+            Twitter API
+
+    To get these credentials, visit https://dev.twitter.com/.
+    '''
+
     _env_keys = ('TWITTER_CONSUMER_KEY', 'TWITTER_CONSUMER_SECRET',
                  'TWITTER_ACCESS_TOKEN_KEY', 'TWITTER_ACCESS_TOKEN_SECRET')
 
     def __init__(self, consumer_key=None, consumer_secret=None,
-                 access_token_key=None, access_token_secret=None,
-                 status_id=None):
+                 access_token_key=None, access_token_secret=None):
         import twitter
 
         if consumer_key is None or consumer_secret is None or \
@@ -38,9 +48,30 @@ class TweetStim(CompoundStim, EnvironmentKeyMixin):
                                access_token_key=access_token_key,
                                access_token_secret=access_token_secret)
         self.api.VerifyCredentials()
-        self.status = self.api.GetStatus(status_id)
-        elements = [TextStim(text=self.status.text)]
-        if self.status.media:
-            media_stims = load_stims([m.media_url for m in self.status.media])
+
+    def get_status(self, status_id):
+        status = self.api.GetStatus(status_id)
+        return TweetStim(status)
+
+
+class TweetStim(CompoundStim):
+
+    '''
+    Represents the text and associated media from a single tweet.
+
+    Args:
+        status (python-twitter Status objcet): the Status from which to
+            extract information, can either be generated from the TweetFactory
+            or user-provided.
+    '''
+
+    _allowed_types = (TextStim, ImageStim, VideoStim)
+    _allow_multiple = True
+    _primary = TextStim
+
+    def __init__(self, status):
+        elements = [TextStim(text=status.text)]
+        if status.media:
+            media_stims = load_stims([m.media_url for m in status.media])
             elements.extend(media_stims)
         super(TweetStim, self).__init__(elements=elements)

--- a/pliers/stimuli/api.py
+++ b/pliers/stimuli/api.py
@@ -7,6 +7,11 @@ from .text import TextStim
 from .video import VideoStim
 from pliers.transformers import EnvironmentKeyMixin
 
+try:
+    import twitter
+except ImportError:
+    twitter = None
+
 
 class TweetStimFactory(EnvironmentKeyMixin):
 
@@ -29,8 +34,10 @@ class TweetStimFactory(EnvironmentKeyMixin):
 
     def __init__(self, consumer_key=None, consumer_secret=None,
                  access_token_key=None, access_token_secret=None):
-        import twitter
-
+        if twitter is None:
+            raise ImportError("python-twitter is required to create a "
+                              "TweetStimFactory, but could not be successfully"
+                              " imported. Please make sure it is installed.")
         if consumer_key is None or consumer_secret is None or \
            access_token_key is None or access_token_secret is None:
             try:

--- a/pliers/stimuli/api.py
+++ b/pliers/stimuli/api.py
@@ -8,7 +8,7 @@ from .video import VideoStim
 from pliers.transformers import EnvironmentKeyMixin
 
 
-class TweetFactory(EnvironmentKeyMixin):
+class TweetStimFactory(EnvironmentKeyMixin):
 
     '''
     An object from which to generate TweetStims, creates an Api instance from
@@ -60,7 +60,7 @@ class TweetStim(CompoundStim):
     Represents the text and associated media from a single tweet.
 
     Args:
-        status (python-twitter Status objcet): the Status from which to
+        status (python-twitter Status object): the Status from which to
             extract information, can either be generated from the TweetFactory
             or user-provided.
     '''
@@ -70,6 +70,7 @@ class TweetStim(CompoundStim):
     _primary = TextStim
 
     def __init__(self, status):
+        self.status = status
         elements = [TextStim(text=status.text)]
         if status.media:
             media_stims = load_stims([m.media_url for m in status.media])

--- a/pliers/tests/test_stims.py
+++ b/pliers/tests/test_stims.py
@@ -233,6 +233,7 @@ def test_save():
         os.remove(path)
 
 
+@pytest.mark.skipif("'TWITTER_ACCESS_TOKEN_KEY' not in os.environ")
 def test_twitter():
     # Test stim creation
     pytest.importorskip('twitter')

--- a/pliers/tests/test_stims.py
+++ b/pliers/tests/test_stims.py
@@ -2,9 +2,11 @@ from .utils import get_test_data_path
 from pliers.stimuli import (VideoStim, VideoFrameStim, ComplexTextStim,
                             AudioStim, ImageStim, CompoundStim,
                             TranscribedAudioCompoundStim,
-                            TextStim)
+                            TextStim,
+                            TweetStimFactory,
+                            TweetStim)
 from pliers.stimuli.base import Stim, _get_stim_class
-from pliers.extractors import BrightnessExtractor
+from pliers.extractors import BrightnessExtractor, LengthExtractor
 from pliers.extractors.base import Extractor, ExtractorResult
 from pliers.support.download import download_nltk_data
 import numpy as np
@@ -229,3 +231,29 @@ def test_save():
         s.save(path)
         assert exists(path)
         os.remove(path)
+
+
+def test_twitter():
+    # Test stim creation
+    pytest.importorskip('twitter')
+    factory = TweetStimFactory()
+    status_id = 821442726461931521
+    pliers_tweet = factory.get_status(status_id)
+    assert isinstance(pliers_tweet, TweetStim)
+    assert isinstance(pliers_tweet, CompoundStim)
+    assert len(pliers_tweet.elements) == 1
+
+    status_id = 884392294014746624
+    ut_tweet = factory.get_status(status_id)
+    assert len(ut_tweet.elements) == 2
+
+    # Test extraction
+    ext = LengthExtractor()
+    res = ext.transform(pliers_tweet)[0].to_df()
+    assert res['text_length'][0] == 104
+
+    # Test image extraction
+    ext = BrightnessExtractor()
+    res = ext.transform(ut_tweet)[0].to_df()
+    brightness = res['brightness'][0]
+    assert np.isclose(brightness, 0.54057, 1e-5)


### PR DESCRIPTION
Got a basic layout for twitter integration for pliers. `TweetStim`s inherit `CompoundStim` such that it can be comprised of text, images, and/or videos. 

Tweets can either by created via the `TweetStimFactory`, which handles the API authentication, or directly by passing a `Status` object from the `python-twitter` library to the `TweetStim` constructor.

Probably could further develop how we get tweets (firehose, other things outside of just status-by-status).

Resolves #131 