### PR TITLE
Force open images in RGB

### DIFF
--- a/pliers/extractors/image.py
+++ b/pliers/extractors/image.py
@@ -20,6 +20,7 @@ class BrightnessExtractor(ImageExtractor):
 
     def _extract(self, stim):
         data = stim.data
+        assert 0
         brightness = np.amax(data, 2).mean() / 255.0
 
         return ExtractorResult(np.array([[brightness]]), stim, self,

--- a/pliers/extractors/image.py
+++ b/pliers/extractors/image.py
@@ -20,7 +20,6 @@ class BrightnessExtractor(ImageExtractor):
 
     def _extract(self, stim):
         data = stim.data
-        assert 0
         brightness = np.amax(data, 2).mean() / 255.0
 
         return ExtractorResult(np.array([[brightness]]), stim, self,

--- a/pliers/stimuli/image.py
+++ b/pliers/stimuli/image.py
@@ -27,9 +27,10 @@ class ImageStim(Stim):
 
     def __init__(self, filename=None, onset=None, duration=None, data=None, url=None):
         if data is None and isinstance(filename, six.string_types):
-            data = imread(filename)
+            data = imread(filename, mode='RGB')
         if url is not None:
             img = Image.open(io.BytesIO(urlopen(url).read()))
+            img = img.convert(mode='RGB')
             data = np.array(img)
             filename = url
         self.data = data


### PR DESCRIPTION
To fix #184 we can force RGB when opening images. 

It might be useful to also add BW images to the test suite. Any free images we can use?
Maybe this one? https://en.wikipedia.org/wiki/File:Grayscale_8bits_palette_sample_image.png
Might be overkill though.