### PR TITLE
POS tag extractor fix

### DIFF
--- a/pliers/extractors/text.py
+++ b/pliers/extractors/text.py
@@ -192,10 +192,10 @@ class PartOfSpeechExtractor(BatchTransformerMixin, TextExtractor):
         results = []
         tagset = nltk.data.load('help/tagsets/upenn_tagset.pickle').keys()
         for i, s in enumerate(stims):
-            pos_vector = [0] * len(tagset)
-            pos_vector[tagset.index(pos[i][1])] = 1
-            results.append(ExtractorResult([pos_vector], s, self,
-                                           features=tagset))
+            pos_vector = dict.fromkeys(tagset, 0)
+            pos_vector[pos[i][1]] = 1
+            results.append(ExtractorResult([pos_vector.values()], s, self,
+                                           features=pos_vector.keys()))
 
         return results
 

--- a/pliers/extractors/text.py
+++ b/pliers/extractors/text.py
@@ -195,7 +195,7 @@ class PartOfSpeechExtractor(BatchTransformerMixin, TextExtractor):
             pos_vector = dict.fromkeys(tagset, 0)
             pos_vector[pos[i][1]] = 1
             results.append(ExtractorResult([pos_vector.values()], s, self,
-                                           features=pos_vector.keys()))
+                                           features=list(pos_vector.keys())))
 
         return results
 

--- a/pliers/extractors/text.py
+++ b/pliers/extractors/text.py
@@ -174,34 +174,30 @@ class NumUniqueWordsExtractor(TextExtractor):
                                features=['num_unique_words'])
 
 
-class PartOfSpeechExtractor(ComplexTextExtractor):
+class PartOfSpeechExtractor(BatchTransformerMixin, TextExtractor):
 
     ''' Tags parts of speech in text with nltk. '''
 
+    _batch_size = sys.maxsize
+
     @requires_nltk_corpus
-    def _extract(self, stim):
-        words = [w.text for w in stim]
+    def _extract(self, stims):
+        words = [w.text for w in stims]
         pos = nltk.pos_tag(words)
         if len(words) != len(pos):
             raise PliersError(
-                "The number of words in the ComplexTextStim does not match "
-                "the number of tagged words returned by nltk's part-of-speech"
-                " tagger.")
+                "The number of words does not match the number of tagged words"
+                "returned by nltk's part-of-speech tagger.")
 
-        data = {}
-        onsets = []
-        durations = []
-        for i, w in enumerate(stim):
-            p = pos[i][1]
-            if p not in data:
-                data[p] = [0] * len(words)
-            data[p][i] += 1
-            onsets.append(w.onset)
-            durations.append(w.duration)
+        results = []
+        tagset = nltk.data.load('help/tagsets/upenn_tagset.pickle').keys()
+        for i, s in enumerate(stims):
+            pos_vector = [0] * len(tagset)
+            pos_vector[tagset.index(pos[i][1])] = 1
+            results.append(ExtractorResult([pos_vector], s, self,
+                                           features=tagset))
 
-        return ExtractorResult(np.array(list(data.values())).transpose(),
-                               stim, self, features=list(data.keys()),
-                               onsets=onsets, durations=durations)
+        return results
 
 
 class WordEmbeddingExtractor(TextExtractor):

--- a/pliers/tests/test_datasets.py
+++ b/pliers/tests/test_datasets.py
@@ -8,7 +8,7 @@ def test_dicts_exist_at_url_and_initialize():
     """
     datasets = _load_datasets()
     for name, dataset in datasets.items():
-        r = requests.head(dataset['url'])
+        r = requests.get(dataset['url'])
         assert r.status_code == requests.codes.ok
         # read_excel() is doing some weird things, so disable for the moment
         # data = fetch_dictionary(name, save=False)

--- a/pliers/tests/test_extractors.py
+++ b/pliers/tests/test_extractors.py
@@ -345,9 +345,8 @@ def test_tempogram_extractor():
 
 def test_part_of_speech_extractor():
     stim = ComplexTextStim(join(TEXT_DIR, 'complex_stim_with_header.txt'))
-    result = PartOfSpeechExtractor().transform(stim).to_df()
-    assert result.shape == (4, 6)
-    assert 'NN' in result.columns
+    result = merge_results(PartOfSpeechExtractor().transform(stim), extractor_names=False)
+    assert result.shape == (4, 52)
     assert result['NN'].sum() == 1
     assert result['VBD'][3] == 1
 

--- a/pliers/tests/test_extractors.py
+++ b/pliers/tests/test_extractors.py
@@ -344,6 +344,8 @@ def test_tempogram_extractor():
 
 
 def test_part_of_speech_extractor():
+    import nltk
+    nltk.download('tagsets')
     stim = ComplexTextStim(join(TEXT_DIR, 'complex_stim_with_header.txt'))
     result = merge_results(PartOfSpeechExtractor().transform(stim), extractor_names=False)
     assert result.shape == (4, 52)


### PR DESCRIPTION
 The POS tag extractor now operates on `TextStim` units instead of `ComplexTextStim`s, which conforms better to the rest of the text transformers.

Also using GET requests in `test_datasets` because the HEAD requests were failing all of the sudden.