### PR TITLE
Static versioning for transformers

### DIFF
--- a/pliers/converters/api.py
+++ b/pliers/converters/api.py
@@ -25,6 +25,7 @@ class SpeechRecognitionAPIConverter(AudioToTextConverter, EnvironmentKeyMixin):
     '''
 
     _log_attributes = ('recognize_method',)
+    VERSION = '1.0'
 
     @abstractproperty
     def recognize_method(self):
@@ -94,6 +95,7 @@ class IBMSpeechAPIConverter(AudioToTextConverter, EnvironmentKeyMixin):
 
     _env_keys = ('IBM_USERNAME', 'IBM_PASSWORD')
     _log_attributes = ('resolution',)
+    VERSION = '1.0'
 
     def __init__(self, username=None, password=None, resolution='words'):
         verify_dependencies(['sr'])

--- a/pliers/converters/google.py
+++ b/pliers/converters/google.py
@@ -20,6 +20,7 @@ class GoogleVisionAPITextConverter(GoogleVisionAPITransformer, ImageToTextConver
 
     request_type = 'TEXT_DETECTION'
     response_object = 'textAnnotations'
+    VERSION = '1.0'
 
     def __init__(self, handle_annotations='first', *args, **kwargs):
         super(GoogleVisionAPITextConverter, self).__init__(*args, **kwargs)

--- a/pliers/converters/image.py
+++ b/pliers/converters/image.py
@@ -21,6 +21,8 @@ class TesseractConverter(ImageToTextConverter):
 
     ''' Uses the Tesseract library to extract text from images. '''
 
+    VERSION = '1.0'
+
     def _convert(self, stim):
         verify_dependencies(['pytesseract'])
         text = pytesseract.image_to_string(Image.fromarray(stim.data))

--- a/pliers/converters/iterators.py
+++ b/pliers/converters/iterators.py
@@ -11,6 +11,8 @@ class StimCollectionIterator(Converter):
 
     ''' Base class for all StimCollectionIterators. '''
 
+    VERSION = '1.0'
+
     def _convert(self, stim):
         return stim.__iter__()
 

--- a/pliers/converters/video.py
+++ b/pliers/converters/video.py
@@ -11,6 +11,7 @@ class VideoToAudioConverter(Converter):
     using moviepy. '''
     _input_type = VideoStim
     _output_type = AudioStim
+    VERSION = '1.0'
 
     def _convert(self, video):
         return AudioStim(clip=video.clip.audio, onset=video.onset)

--- a/pliers/extractors/api.py
+++ b/pliers/extractors/api.py
@@ -38,6 +38,7 @@ class IndicoAPIExtractor(BatchTransformerMixin, Extractor,
     _input_type = ()
     _batch_size = 20
     _env_keys = 'INDICO_APP_KEY'
+    VERSION = '1.0'
 
     def __init__(self, api_key=None, models=None):
         verify_dependencies(['indicoio'])
@@ -132,6 +133,7 @@ class ClarifaiAPIExtractor(BatchTransformerMixin, ImageExtractor,
     _log_attributes = ('model', 'min_value', 'max_concepts', 'select_concepts')
     _batch_size = 128
     _env_keys = ('CLARIFAI_APP_ID', 'CLARIFAI_APP_SECRET')
+    VERSION = '1.0'
 
     def __init__(self, app_id=None, app_secret=None, model='general-v1.3',
                  min_value=None,

--- a/pliers/extractors/audio.py
+++ b/pliers/extractors/audio.py
@@ -40,6 +40,7 @@ class STFTAudioExtractor(AudioExtractor):
     '''
 
     _log_attributes = ('frame_size', 'hop_size', 'freq_bins')
+    VERSION = '1.0'
 
     def __init__(self, frame_size=0.5, hop_size=0.1, freq_bins=5,
                  spectrogram=False):

--- a/pliers/extractors/google.py
+++ b/pliers/extractors/google.py
@@ -10,6 +10,8 @@ class GoogleVisionAPIExtractor(GoogleVisionAPITransformer, ImageExtractor):
 
     ''' Base class for all Extractors that use the Google Vision API. '''
 
+    VERSION = '1.0'
+
     def _extract(self, stims):
         request = self._build_request(stims)
         responses = self._query_api(request)

--- a/pliers/extractors/image.py
+++ b/pliers/extractors/image.py
@@ -21,6 +21,8 @@ class BrightnessExtractor(ImageExtractor):
 
     ''' Gets the average luminosity of the pixels in the image '''
 
+    VERSION = '1.0'
+
     def _extract(self, stim):
         data = stim.data
         brightness = np.amax(data, 2).mean() / 255.0
@@ -32,6 +34,8 @@ class BrightnessExtractor(ImageExtractor):
 class SharpnessExtractor(ImageExtractor):
 
     ''' Gets the degree of blur/sharpness of the image '''
+
+    VERSION = '1.0'
 
     def _extract(self, stim):
         verify_dependencies(['cv2'])
@@ -49,6 +53,8 @@ class SharpnessExtractor(ImageExtractor):
 class VibranceExtractor(ImageExtractor):
 
     ''' Gets the variance of color channels of the image '''
+
+    VERSION = '1.0'
 
     def _extract(self, stim):
         data = stim.data

--- a/pliers/extractors/models.py
+++ b/pliers/extractors/models.py
@@ -25,6 +25,7 @@ class TensorFlowInceptionV3Extractor(ImageExtractor):
      '''
 
     _log_attributes = ('model_dir', 'data_url', 'num_predictions')
+    VERSION = '1.0'
 
     def __init__(self, model_dir=None, data_url=None, num_predictions=5):
 

--- a/pliers/extractors/text.py
+++ b/pliers/extractors/text.py
@@ -60,6 +60,7 @@ class DictionaryExtractor(TextExtractor):
     '''
 
     _log_attributes = ('dictionary', 'variables', 'missing')
+    VERSION = '1.0'
 
     def __init__(self, dictionary, variables=None, missing=np.nan):
         if isinstance(dictionary, string_types):
@@ -110,6 +111,7 @@ class PredefinedDictionaryExtractor(DictionaryExtractor):
     '''
 
     _log_attributes = ('variables', 'missing', 'case_sensitive')
+    VERSION = '1.0'
 
     def __init__(self, variables, missing=np.nan, case_sensitive=True):
 
@@ -144,6 +146,8 @@ class LengthExtractor(TextExtractor):
 
     ''' Extracts the length of the text in characters. '''
 
+    VERSION = '1.0'
+
     def _extract(self, stim):
         return ExtractorResult(np.array([[len(stim.text.strip())]]), stim,
                                self, features=['text_length'])
@@ -154,6 +158,7 @@ class NumUniqueWordsExtractor(TextExtractor):
     ''' Extracts the number of unique words used in the text. '''
 
     _log_attributes = ('tokenizer',)
+    VERSION = '1.0'
 
     def __init__(self, tokenizer=None):
         super(NumUniqueWordsExtractor, self).__init__()
@@ -177,6 +182,8 @@ class NumUniqueWordsExtractor(TextExtractor):
 class PartOfSpeechExtractor(ComplexTextExtractor):
 
     ''' Tags parts of speech in text with nltk. '''
+
+    VERSION = '1.0'
 
     @requires_nltk_corpus
     def _extract(self, stim):
@@ -281,6 +288,7 @@ class VADERSentimentExtractor(TextExtractor):
     score ranging from -1 (very negative) to +1 (very positive). '''
 
     _log_attributes = ('analyzer',)
+    VERSION = '1.0'
 
     def __init__(self):
         self.analyzer = SentimentIntensityAnalyzer()

--- a/pliers/filters/image.py
+++ b/pliers/filters/image.py
@@ -25,6 +25,7 @@ class ImageCroppingFilter(ImageFilter):
     '''
 
     _log_attributes = ('box',)
+    VERSION = '1.0'
 
     def __init__(self, box=None):
         self.box = box

--- a/pliers/filters/video.py
+++ b/pliers/filters/video.py
@@ -23,6 +23,7 @@ class FrameSamplingFilter(VideoFilter):
     '''
 
     _log_attributes = ('every', 'hertz', 'top_n')
+    VERSION = '1.0'
 
     def __init__(self, every=None, hertz=None, top_n=None):
         if every is None and hertz is None and top_n is None:

--- a/pliers/tests/test_transformers.py
+++ b/pliers/tests/test_transformers.py
@@ -90,3 +90,10 @@ def test_validation_levels(capsys):
     res = ext.transform([stim, stim2], validation='loose')
     assert len(res) == 1
     assert np.isclose(res[0].to_df()['brightness'][0], 0.88784294, 1e-5)
+
+
+def test_versioning():
+    ext = DummyBatchExtractor()
+    assert ext.VERSION == '0.1'
+    ext = BrightnessExtractor()
+    assert ext.VERSION >= '1.0'

--- a/pliers/transformers.py
+++ b/pliers/transformers.py
@@ -3,7 +3,7 @@
 from pliers import config
 from pliers.stimuli.base import Stim, _log_transformation, load_stims
 from pliers.stimuli.compound import CompoundStim
-from pliers.utils import (classproperty, progress_bar_wrapper, isiterable,
+from pliers.utils import (progress_bar_wrapper, isiterable,
                           isgenerator, listify, batch_iterable,
                           attempt_to_import)
 import pliers
@@ -22,6 +22,7 @@ class Transformer(with_metaclass(ABCMeta)):
 
     _log_attributes = ()
     _loggable = True
+    VERSION = '0.1'
 
     # Stim types that *can* be passed as input, but aren't mandatory. This
     # allows for disjunctive specification; e.g., if _input_type is empty

--- a/pliers/utils.py
+++ b/pliers/utils.py
@@ -1,6 +1,5 @@
 import collections
 import os
-from abc import abstractproperty
 from six import string_types
 from tqdm import tqdm
 from pliers import config


### PR DESCRIPTION
Resolves #191.
I was fairly conservative with which are "prime time", but those that are have `VERSION="1.0"`. Otherwise, the others have no version specified and default to `VERSION="0.1"` as specified in the Transformers base class in `transformers.py`