### PR TITLE
Quick fixes in Indico extractors

### DIFF
--- a/pliers/datasets/dictionaries.json
+++ b/pliers/datasets/dictionaries.json
@@ -57,7 +57,7 @@
         "title": "SUBTLEX US English word frequency for 60,384 words that have a frequency higher than 1",
         "description_url": "http://www.ugent.be/pp/experimentele-psychologie/en/research/documents/subtlexus/overview.htm",
         "source": "Brysbaert, M., & New, B. (2009). Moving beyond Kučera and Francis: A critical evaluation of current word frequency norms and the introduction of a new and improved word frequency measure for American English. Behavior research methods, 41(4), 977-990.",
-        "url": "http://www.ugent.be/pp/experimentele-psychologie/en/research/documents/subtlexus/subtlexus4.zip/at_download/file",
+        "url": "https://www.ugent.be/pp/experimentele-psychologie/en/research/documents/subtlexus/subtlexus4.zip/at_download/file",
         "license": "",
         "format": "xls",
         "language": "english",

--- a/pliers/extractors/api.py
+++ b/pliers/extractors/api.py
@@ -84,7 +84,7 @@ class IndicoAPIExtractor(BatchTransformerMixin, Extractor,
             results.append(ExtractorResult([data], stim, self,
                                            features=features,
                                            onsets=stim.onset,
-                                           durations=stim.onset))
+                                           durations=stim.duration))
 
         return results
 
@@ -96,6 +96,7 @@ class IndicoAPITextExtractor(TextExtractor, IndicoAPIExtractor):
     '''
 
     def __init__(self, **kwargs):
+        verify_dependencies(['indicoio'])
         self.allowed_models = indicoio.TEXT_APIS.keys()
         super(IndicoAPITextExtractor, self).__init__(**kwargs)
 
@@ -107,6 +108,7 @@ class IndicoAPIImageExtractor(ImageExtractor, IndicoAPIExtractor):
     '''
 
     def __init__(self, **kwargs):
+        verify_dependencies(['indicoio'])
         self.allowed_models = indicoio.IMAGE_APIS.keys()
         super(IndicoAPIImageExtractor, self).__init__(**kwargs)
 

--- a/pliers/tests/test_datasets.py
+++ b/pliers/tests/test_datasets.py
@@ -8,7 +8,7 @@ def test_dicts_exist_at_url_and_initialize():
     """
     datasets = _load_datasets()
     for name, dataset in datasets.items():
-        r = requests.get(dataset['url'])
+        r = requests.head(dataset['url'])
         assert r.status_code == requests.codes.ok
         # read_excel() is doing some weird things, so disable for the moment
         # data = fetch_dictionary(name, save=False)


### PR DESCRIPTION
The extractor was accidentally setting the `ExtractorResult` duration to `stim.onset` instead of `stim.duration`.

The Text and Image subclasses of `IndicoAPIExtractor` need to have dependency verification before trying to access the `allowed_models`.