### PR TITLE
Better config

### DIFF
--- a/pliers/__init__.py
+++ b/pliers/__init__.py
@@ -1,6 +1,10 @@
+from .config import set_option, get_option
+
 
 __all__ = [
-    'config',
+    'config'
+    'set_option',
+    'get_option',
     'export',
     'google',
     'graph',

--- a/pliers/config.py
+++ b/pliers/config.py
@@ -27,11 +27,15 @@ _default_settings = {
 }
 
 
-def set_option(**kwargs):
+def set_option(key, value):
+    if key not in _settings:
+        raise ValueError("Invalid pliers setting: '%s'" % key)
+    _settings[key] = value
+
+
+def set_options(**kwargs):
     for k, v in kwargs.items():
-        if k not in _settings:
-            raise ValueError("Invalid pliers setting: '%s'" % k)
-        _settings[k] = v
+        set_option(k, v)
 
 
 def get_option(key):

--- a/pliers/config.py
+++ b/pliers/config.py
@@ -1,10 +1,82 @@
-cache_transformers = True
-log_transformations = True
-drop_bad_extractor_results = True
-progress_bar = True
-parallelize = False
-n_jobs = None
-default_converters = {
-    'AudioStim->TextStim': ('IBMSpeechAPIConverter', 'WitTranscriptionConverter'),
-    'ImageStim->TextStim': ('GoogleVisionAPITextConverter', 'TesseractConverter')
+''' The config module contains package-level settings and tools for
+manipulating them. '''
+
+import json
+from os.path import join, expanduser, exists
+import os
+from six import string_types
+
+
+_config_name = 'pliers_config.json'
+
+_default_converters = {
+    'AudioStim->TextStim':
+        ('IBMSpeechAPIConverter', 'WitTranscriptionConverter'),
+    'ImageStim->TextStim':
+        ('GoogleVisionAPITextConverter', 'TesseractConverter')
 }
+
+_default_settings = {
+    'cache_transformers': True,
+    'default_converters': _default_converters,
+    'drop_bad_extractor_results': True,
+    'log_transformations': True,
+    'n_jobs': None,
+    'parallelize': False,
+    'progress_bar': True
+}
+
+
+def set_option(**kwargs):
+    for k, v in kwargs.items():
+        if k not in _settings:
+            raise ValueError("Invalid pliers setting: '%s'" % k)
+        _settings[k] = v
+
+
+def get_option(key):
+    if key not in _settings:
+        raise ValueError("Invalid pliers setting: '%s'" % key)
+    return _settings[key]
+
+
+def from_file(filenames, error_on_missing=True):
+    if isinstance(filenames, string_types):
+        filenames = [filenames]
+    for f in filenames:
+        if exists(f):
+            settings = json.load(open(f))
+            _settings.update(settings)
+        elif error_on_missing:
+            raise ValueError("Config file '%s' does not exist." % f)
+
+
+def reset_options(update_from_file=False):
+    ''' Reset all options to the package defaults.
+    Args:
+        from_file (bool): If True, re-applies any config files found in
+            standard locations.
+    '''
+    global _settings
+    _settings = _default_settings.copy()
+    if update_from_file:
+        _update_from_standard_locations()
+
+
+def _update_from_standard_locations():
+    ''' Check standard locations for config files and update settings if found.
+    Order is user's home dir, environment variable ($PLIERS_CONFIG), and then
+    current directory--with later files taking precedence over earlier ones.
+    '''
+    locs = [
+        join(expanduser('~'), _config_name),
+        join('.', _config_name)
+    ]
+    if 'PLIERS_CONFIG' in os.environ:
+        locs.insert(1, os.environ['PLIERS_CONFIG'])
+
+    from_file(locs, False)
+
+
+_settings = {}
+reset_options(True)

--- a/pliers/converters/base.py
+++ b/pliers/converters/base.py
@@ -41,18 +41,22 @@ def get_converter(in_type, out_type, *args, **kwargs):
     # If config includes default converters for this combination, try them
     # first
     out_type = listify(out_type)[::-1]
+    default_convs = config.get_option('default_converters')
+
     for ot in out_type:
         conv_str = '%s->%s' % (in_type.__name__, ot.__name__)
-        if conv_str in config.default_converters:
-            convs = list(config.default_converters[conv_str]) + convs
+        if conv_str in default_convs:
+            convs = list(default_convs[conv_str]) + convs
 
     for name in convs:
         cls = getattr(pliers.converters, name)
         if not issubclass(cls, Converter):
             continue
 
-        available = cls.available if issubclass(cls, EnvironmentKeyMixin) else True
-        if cls._input_type == in_type and cls._output_type in out_type and available:
+        available = cls.available if issubclass(
+            cls, EnvironmentKeyMixin) else True
+        if cls._input_type == in_type and cls._output_type in out_type \
+                and available:
             conv = cls(*args, **kwargs)
             return conv
 

--- a/pliers/stimuli/base.py
+++ b/pliers/stimuli/base.py
@@ -155,7 +155,7 @@ def load_stims(source, dtype=None, fail_silently=False):
 
 def _log_transformation(source, result, trans=None):
 
-    if result is None or not config.log_transformations or \
+    if result is None or not config.get_option('log_transformations') or \
             (trans is not None and not trans._loggable):
         return result
 

--- a/pliers/tests/test_config.py
+++ b/pliers/tests/test_config.py
@@ -1,0 +1,61 @@
+import pliers
+import tempfile
+import os
+import json
+import pytest
+from pliers.config import reset_options
+
+def test_load_from_standard_paths():
+
+    # Verify defaults
+    reset_options(update_from_file=False)
+    assert pliers.config._settings == pliers.config._default_settings
+
+    # Verify that PLIERS_CONFIG and local dir take precedence
+    env_config = {"n_jobs": 200, "log_transformations": False}
+    cwd_config = {"log_transformations": True, "parallelize": True}
+
+    handle, f = tempfile.mkstemp(suffix='.json')
+    json.dump(env_config, open(f, 'w'))
+    os.environ['PLIERS_CONFIG'] = f
+
+    target = 'pliers_config.json'
+    if os.path.exists(target):
+        pytest.skip("Cannot test pliers config because the default config file"
+                    " (pliers_config.json) already exists in the current "
+                    "working directory. Skipping test to avoid overwriting.")
+    json.dump(cwd_config, open(target, 'w'))
+
+    reset_options(True)
+
+    os.unlink(target)
+
+    opts = pliers.config._settings
+
+    assert opts['n_jobs'] == 200
+    assert opts['log_transformations']
+    assert opts['parallelize']
+
+    reset_options(False)
+
+
+def test_set_option():
+
+
+    reset_options(False)
+    opts = pliers.config._settings
+
+    pliers.config.set_option(n_jobs=100, progress_bar=True)
+    assert opts['n_jobs'] == 100
+    assert opts['progress_bar']
+
+    with pytest.raises(ValueError):
+        pliers.config.set_option(bad_key=False)
+
+    reset_options(False)
+
+
+def test_get_option():
+
+    reset_options(False)
+    assert not pliers.config.get_option('parallelize')

--- a/pliers/tests/test_config.py
+++ b/pliers/tests/test_config.py
@@ -45,12 +45,12 @@ def test_set_option():
     reset_options(False)
     opts = pliers.config._settings
 
-    pliers.config.set_option(n_jobs=100, progress_bar=True)
+    pliers.config.set_options(n_jobs=100, progress_bar=True)
     assert opts['n_jobs'] == 100
     assert opts['progress_bar']
 
     with pytest.raises(ValueError):
-        pliers.config.set_option(bad_key=False)
+        pliers.config.set_option('bad_key', False)
 
     reset_options(False)
 

--- a/pliers/tests/test_transformers.py
+++ b/pliers/tests/test_transformers.py
@@ -39,22 +39,22 @@ def test_parallelization():
     # TODO: test that parallelization actually happened (this will likely
     # require some new logging functionality, or introspection). For now we
     # just make sure the parallelized version produces the same result.
-    default = config.parallelize
+    default = config.get_option('parallelize')
 
     filename = join(get_test_data_path(), 'video', 'small.mp4')
     video = VideoStim(filename)
     ext = BrightnessExtractor()
 
     # With parallelization
-    config.parallelize = True
+    config.set_option(parallelize=True)
     result1 = ext.transform(video)
 
     # Without parallelization
-    config.parallelize = False
+    config.set_option(parallelize=False)
     result2 = ext.transform(video)
 
     assert result1 == result2
-    config.parallelize = default
+    config.set_option(parallelize=default)
 
 
 def test_batch_transformer():

--- a/pliers/tests/test_utils.py
+++ b/pliers/tests/test_utils.py
@@ -16,19 +16,19 @@ def test_progress_bar(capfd):
     video = VideoStim(join(video_dir, 'obama_speech.mp4'))
     conv = FrameSamplingFilter(hertz=2)
 
-    old_val = config.progress_bar
-    config.progress_bar = True
+    old_val = config.get_option('progress_bar')
+    config.set_option(progress_bar=True)
 
     derived = conv.transform(video)
     out, err = capfd.readouterr()
     assert 'Video frame:' in err and '100%' in err
 
-    config.progress_bar = False
+    config.set_option(progress_bar=False)
     derived = conv.transform(video)
     out, err = capfd.readouterr()
     assert 'Video frame:' not in err and '100%' not in err
 
-    config.progress_bar = old_val
+    config.set_option(progress_bar=old_val)
 
 
 def test_batch_iterable():

--- a/pliers/transformers.py
+++ b/pliers/transformers.py
@@ -38,7 +38,8 @@ class Transformer(with_metaclass(ABCMeta)):
 
     def _memoize(transform):
         def wrapper(self, stim, *args, **kwargs):
-            use_cache = config.cache_transformers and isinstance(stim, Stim)
+            use_cache = config.get_option('cache_transformers') \
+                and isinstance(stim, Stim)
             if use_cache:
                 key = hash((hash(self), hash(stim)))
                 if key in _cache:
@@ -69,7 +70,7 @@ class Transformer(with_metaclass(ABCMeta)):
         # invalid results if needed
         if isiterable(stims):
             iters = self._iterate(stims, *args, **kwargs)
-            if config.drop_bad_extractor_results:
+            if config.get_option('drop_bad_extractor_results'):
                 iters = (i for i in iters if i is not None)
             return progress_bar_wrapper(iters, desc='Stim')
 
@@ -135,12 +136,17 @@ class Transformer(with_metaclass(ABCMeta)):
 
     def _iterate(self, stims, *args, **kwargs):
 
-        if config.parallelize and multiprocessing is not None:
+        if config.get_option('parallelize') and multiprocessing is not None:
+
             def _transform(s):
                 return self.transform(s, *args, **kwargs)
-            return multiprocessing.ProcessingPool(config.n_jobs).map(_transform, stims)
 
-        return (t for t in (self.transform(s, *args, **kwargs) for s in stims) if t)
+            n_jobs = config.get_option('n_jobs')
+            return multiprocessing.ProcessingPool(n_jobs) \
+                .map(_transform, stims)
+
+        return (t for t in (self.transform(s, *args, **kwargs)
+                            for s in stims) if t)
 
     @abstractmethod
     def _transform(self, stim):

--- a/pliers/utils/base.py
+++ b/pliers/utils/base.py
@@ -60,8 +60,8 @@ def isgenerator(obj):
 def progress_bar_wrapper(iterable, **kwargs):
     ''' Wrapper that applies tqdm progress bar conditional on config settings.
     '''
-    return tqdm(iterable, **kwargs) if (config.progress_bar and
-        not isinstance(iterable, tqdm)) else iterable
+    return tqdm(iterable, **kwargs) if (config.get_option('progress_bar')
+        and not isinstance(iterable, tqdm)) else iterable
 
 
 module_names = {}


### PR DESCRIPTION
This PR beefs up the config module to bring it more in line with other packages. Instead of directly accessing attributes in `pliers.config` (e.g., `pliers.config.parallelize`), access is now restricted through `config.get_option()` and `config.set_option()` methods.

Additionally, the package now scans in standard locations (user's home directory, and current working directory) for `pliers_config.json` files, which override package-level settings if found. The user can also set the `PLIERS_CONFIG` environment variable with a filename that is handled in the same way.

I'm not 100% satisfied with this--e.g., the get_ and set_ methods are currently inconsistent; it's `.get_option('parallelize')`, but `.set_option(parallelize=True)`). But on the whole I think this is a big improvement.

Closes #108.