### PR TITLE
fix: bare installation

### DIFF
--- a/pliers/__init__.py
+++ b/pliers/__init__.py
@@ -1,6 +1,6 @@
 from .config import set_option, get_option, set_options
 from .graph import Graph
-
+from .version import __version__
 
 __all__ = [
     'config'

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,20 @@
-from pliers.version import __version__
 from setuptools import setup, find_packages
+import os
 
 extra_setuptools_args = dict(
     tests_require=['pytest']
 )
 
+thispath, _ = os.path.split(__file__)
+
+ver_file = os.path.join(thispath, 'pliers', 'version.py')
+
+with open(ver_file) as fp:
+    exec(fp.read(), globals(), locals())
+
 setup(
     name="pliers",
-    version=__version__,
+    version=locals()['__version__'],
     description="Multimodal feature extraction in Python",
     maintainer='Tal Yarkoni',
     maintainer_email='tyarkoni@gmail.com',


### PR DESCRIPTION
currently, if installing into environment without `six`, importing `__version__` within `setup.py` leads to a chain of imports that break installation.

This PR avoids this import and parses the variables within `version.py` directly, as well as allows easier version checking
```
python -c "import pliers; print(pliers.__version__)"
```