### PR TITLE
BF: parse version.py for __version__ instead of trying to import pliers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,23 @@
-from pliers.version import __version__
+from os.path import dirname, join as opj
 from setuptools import setup, find_packages
+
+
+def get_version():
+    """Load version from version.py without entailing any imports
+    """
+    # This might entail lots of imports which might not yet be available
+    # so let's do ad-hoc parsing of the version.py
+    with open(opj(dirname(__file__), 'pliers', 'version.py')) as f:
+        version_lines = list(filter(lambda x: x.startswith('__version__'), f))
+    assert (len(version_lines) == 1)
+    return version_lines[0].split('=')[1].strip(" '\"\t\n")
+
 
 extra_setuptools_args = dict(
     tests_require=['pytest']
 )
+
+__version__ = get_version()
 
 setup(
     name="pliers",
@@ -21,6 +35,6 @@ setup(
                   },
     zip_safe=False,
     download_url='https://github.com/tyarkoni/pliers/archive/%s.tar.gz' %
-    __version__,
+        __version__,
     **extra_setuptools_args
 )


### PR DESCRIPTION
To be able to run "pip install ." etc when dependencies are not yet available,
imports would fail etc:

```shell
$> pip install -e .
Obtaining file:///home/yoh/proj/misc/pliers
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/home/yoh/proj/misc/pliers/setup.py", line 1, in <module>
        from pliers.version import __version__
      File "pliers/__init__.py", line 2, in <module>
        from .graph import Graph
      File "pliers/graph.py", line 4, in <module>
        from pliers.extractors.base import Extractor, merge_results
      File "pliers/extractors/__init__.py", line 6, in <module>
        from .base import Extractor, ExtractorResult, merge_results
      File "pliers/extractors/base.py", line 7, in <module>
        from pliers.transformers import Transformer
      File "pliers/transformers/__init__.py", line 6, in <module>
        from .base import Transformer, BatchTransformerMixin, get_transformer
      File "pliers/transformers/base.py", line 4, in <module>
        from pliers.stimuli.base import Stim, _log_transformation, load_stims
      File "pliers/stimuli/__init__.py", line 5, in <module>
        from .api import TweetStim, TweetStimFactory
      File "pliers/stimuli/api.py", line 6, in <module>
        from .compound import CompoundStim
      File "pliers/stimuli/compound.py", line 7, in <module>
        from .audio import AudioStim
      File "pliers/stimuli/audio.py", line 4, in <module>
        from moviepy.audio.io.AudioFileClip import AudioFileClip
    ImportError: No module named moviepy.audio.io.AudioFileClip
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /home/yoh/proj/misc/pliers/
```