### PR TITLE
ENH: Initial support for duecredit

### DIFF
--- a/optional-dependencies.txt
+++ b/optional-dependencies.txt
@@ -1,4 +1,5 @@
 clarifai
+duecredit
 face_recognition
 python-twitter
 gensim

--- a/pliers/__init__.py
+++ b/pliers/__init__.py
@@ -1,6 +1,8 @@
 from .config import set_option, get_option, set_options
 from .graph import Graph
 from .version import __version__
+from .support.due import due, Url, BibTeX
+
 
 __all__ = [
     'config'
@@ -21,12 +23,31 @@ __all__ = [
     'Graph'
 ]
 
-from .support.due import due, Url
-
 # TODO: replace with Doi whenever available (Zenodo?)
 due.cite(
     Url("https://github.com/tyarkoni/pliers"),
-    description="A Python package for automated extraction of features from multimodal stimuli",
+    description="A Python package for automated extraction of features from "
+                "multimodal stimuli",
     tags=['reference-implementation'],
     path='pliers'
 )
+
+due.cite(BibTeX("""
+    @inproceedings{McNamara:2017:DCF:3097983.3098075,
+     author = {McNamara, Quinten and De La Vega, Alejandro and Yarkoni, Tal},
+     title = {Developing a Comprehensive Framework for Multimodal Feature Extraction},
+     booktitle = {Proceedings of the 23rd ACM SIGKDD International Conference on Knowledge Discovery and Data Mining},
+     series = {KDD '17},
+     year = {2017},
+     isbn = {978-1-4503-4887-4},
+     location = {Halifax, NS, Canada},
+     pages = {1567--1574},
+     numpages = {8},
+     url = {http://doi.acm.org/10.1145/3097983.3098075},
+     doi = {10.1145/3097983.3098075},
+     acmid = {3098075},
+     publisher = {ACM},
+     address = {New York, NY, USA},
+     keywords = {feature extraction, multimodal retrieval, python, standardization, wrappers},
+    }"""),
+    description="Developing a Comprehensive Framework for Multimodal Feature Extraction", path="pliers")

--- a/pliers/__init__.py
+++ b/pliers/__init__.py
@@ -20,3 +20,13 @@ __all__ = [
     'support',
     'Graph'
 ]
+
+from .support.due import due, Url
+
+# TODO: replace with Doi whenever available (Zenodo?)
+due.cite(
+    Url("https://github.com/tyarkoni/pliers"),
+    description="A Python package for automated extraction of features from multimodal stimuli",
+    tags=['reference-implementation'],
+    path='pliers'
+)

--- a/pliers/external/pysaliency/__init__.py
+++ b/pliers/external/pysaliency/__init__.py
@@ -1,0 +1,9 @@
+from pliers.support.due import due, Url
+
+due.cite(
+    Url("https://github.com/akisato-/pySaliencyMap"),
+    description="pySaliencyMap module -- Image saliency estimation",
+    path='pySaliencyMap',
+    cite_module=True,
+    tags=["reference-implementation"]
+)

--- a/pliers/extractors/image.py
+++ b/pliers/extractors/image.py
@@ -5,6 +5,7 @@ Extractors that operate primarily or exclusively on Image stimuli.
 from pliers.stimuli.image import ImageStim
 from pliers.extractors.base import Extractor, ExtractorResult
 from pliers.utils import attempt_to_import, verify_dependencies, listify
+from pliers.support.due import due, Url, Doi
 import numpy as np
 import pandas as pd
 from functools import partial
@@ -72,6 +73,10 @@ class SaliencyExtractor(ImageExtractor):
     ''' Determines the saliency of the image using Itti & Koch (1998) algorithm
     implemented in pySaliencyMap '''
 
+    @due.dcite(Doi("10.1109/34.730558"),
+               description="Image saliency estimation",
+               path='pliers.extractors.image.SilencyExtractor',
+               tags=["implementation"])
     def _extract(self, stim):
         from pliers.external.pysaliency import pySaliencyMap
         # pySaliencyMap from https://github.com/akisato-/pySaliencyMap

--- a/pliers/support/due.py
+++ b/pliers/support/due.py
@@ -1,0 +1,73 @@
+# emacs: at the end of the file
+# ex: set sts=4 ts=4 sw=4 et:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### #
+"""
+
+Stub file for a guaranteed safe import of duecredit constructs:  if duecredit
+is not available.
+
+To use it, place it into your project codebase to be imported, e.g. copy as
+
+    cp stub.py /path/tomodule/module/due.py
+
+Note that it might be better to avoid naming it duecredit.py to avoid shadowing
+installed duecredit.
+
+Then use in your code as
+
+    from .due import due, Doi, BibTeX
+
+See  https://github.com/duecredit/duecredit/blob/master/README.md for examples.
+
+Origin:     Originally a part of the duecredit
+Copyright:  2015-2016  DueCredit developers
+License:    BSD-2
+"""
+
+__version__ = '0.0.5'
+
+
+class InactiveDueCreditCollector(object):
+    """Just a stub at the Collector which would not do anything"""
+    def _donothing(self, *args, **kwargs):
+        """Perform no good and no bad"""
+        pass
+
+    def dcite(self, *args, **kwargs):
+        """If I could cite I would"""
+        def nondecorating_decorator(func):
+            return func
+        return nondecorating_decorator
+
+    cite = load = add = _donothing
+
+    def __repr__(self):
+        return self.__class__.__name__ + '()'
+
+
+def _donothing_func(*args, **kwargs):
+    """Perform no good and no bad"""
+    pass
+
+
+try:
+    from duecredit import due, BibTeX, Doi, Url
+    if 'due' in locals() and not hasattr(due, 'cite'):
+        raise RuntimeError(
+            "Imported due lacks .cite. DueCredit is now disabled")
+except Exception as e:
+    if type(e).__name__ != 'ImportError':
+        import logging
+        logging.getLogger("duecredit").error(
+            "Failed to import duecredit due to %s" % str(e))
+    # Initiate due stub
+    due = InactiveDueCreditCollector()
+    BibTeX = Doi = Url = _donothing_func
+
+# Emacs mode definitions
+# Local Variables:
+# mode: python
+# py-indent-offset: 4
+# tab-width: 4
+# indent-tabs-mode: nil
+# End:


### PR DESCRIPTION
- I have placed reference for the article into "pliers" code while citation for the module itself into your copy of the pySilencyMap
- here is currently "used" tags we defined in duecredit: https://github.com/duecredit/duecredit/#tags  If you see how we could improve, please suggest ;)

Demo (including the failing test):
```shell
$> DUECREDIT_ENABLE=1 python -m pytest -s -v pliers/tests/extractors/test_image_extractors.py::test_saliency_extractor
================================================================= test session starts ==================================================================
platform linux2 -- Python 2.7.14+, pytest-3.2.1, py-1.4.34, pluggy-0.4.0 -- /home/yoh/proj/misc/pliers/venvs/dev/bin/python
cachedir: .cache
rootdir: /home/yoh/proj/misc/pliers, inifile:
plugins: xdist-1.18.2, localserver-0.3.7, cov-2.5.1, hypothesis-3.44.1, celery-4.1.0
collected 1 item                                                                                                                                        

pliers/tests/extractors/test_image_extractors.py::test_saliency_extractor FAILED

======================================================================= FAILURES =======================================================================
_______________________________________________________________ test_saliency_extractor ________________________________________________________________

    def test_saliency_extractor():
        pytest.importorskip('cv2')
        stim = ImageStim(join(IMAGE_DIR, 'apple.jpg'))
        result = SaliencyExtractor().transform(stim).to_df()
        ms = result['max_saliency'][0]
        assert np.isclose(ms, 0.99669953, 1e-5)
        sf = result['frac_high_saliency'][0]
>       assert np.isclose(sf, 0.27461971, 1e-5)
E       assert False
E        +  where False = <function isclose at 0x7f31b82ec848>(0.27602513227513226, 0.27461971, 1e-05)
E        +    where <function isclose at 0x7f31b82ec848> = np.isclose

pliers/tests/extractors/test_image_extractors.py:54: AssertionError
=============================================================== 1 failed in 3.87 seconds ===============================================================

DueCredit Report:
- Scientific tools library / numpy (v 1.13.3) [1]
- A Python package for automated extraction of features from multimodal stimuli / pliers (v 0.2.1) [2]
  - Image saliency estimation / pliers.extractors.image.SilencyExtractor (v 0.2.1) [3]
- pySaliencyMap module -- Image saliency estimation / pySaliencyMap (v None) [4]
- Machine Learning library / sklearn (v 0.19.1) [5]
  - Affinity propagation clustering algorithm / sklearn.cluster.affinity_propagation_ (v 0.19.1) [6]

4 packages cited
2 modules cited
0 functions cited

References
----------

[1] Van Der Walt, S., Colbert, S.C. & Varoquaux, G., 2011. The NumPy array: a structure for efficient numerical computation. Computing in Science & Engineering, 13(2), pp.22–30.
[2] Url('https://github.com/tyarkoni/pliers', key='https://github.com/tyarkoni/pliers')
[3] Itti, L., Koch, C. & Niebur, E., 1998. A model of saliency-based visual attention for rapid scene analysis. IEEE Transactions on Pattern Analysis and Machine Intelligence, 20(11), pp.1254–1259.
[4] Url('https://github.com/akisato-/pySaliencyMap', key='https://github.com/akisato-/pysaliencymap')
[5] Pedregosa, F. et al., 2011. Scikit-learn: Machine learning in Python. The Journal of Machine Learning Research, 12, pp.2825–2830.
[6] Frey, B.J. & Dueck, D., 2007. Clustering by Passing Messages Between Data Points. Science, 315(5814), pp.972–976.
```

As for URLs - a fresh TODO https://github.com/duecredit/duecredit/issues/126 

Closes #217