### PR TITLE
Graph improvements

### DIFF
--- a/pliers/graph.py
+++ b/pliers/graph.py
@@ -153,7 +153,6 @@ class Graph(object):
             has_parent = True
 
             while has_parent:
-
                 # Add nodes
                 source_from = log.parent[6] if log.parent else ''
                 s_node = hash((source_from, log[2]))
@@ -209,7 +208,7 @@ class Graph(object):
             node = self.nodes[node]
 
         result = node.transformer.transform(stim)
-        if isinstance(node.transformer, Extractor):
+        if len(node.children) == 0:
             return listify(result)
 
         stim = result

--- a/pliers/graph.py
+++ b/pliers/graph.py
@@ -157,7 +157,20 @@ class Graph(object):
                                "Try calling run() first.")
 
         g = pgv.AGraph(directed=True)
-        node_list = {}
+
+        color_dict = {
+            'AudioStim': 'aquamarine3',
+            'CompoundStim': 'cyan4',
+            'TranscribedAudioCompoundStim': 'cadetblue',
+            'ComplexTextStim': 'springgreen3',
+            'TextStim': 'springgreen2',
+            'VideoStim': 'red3',
+            'VideoFrameCollectionStim': 'tomato3',
+            'VideoFrameStim': 'salmon',
+            'ImageStim': 'indianred',
+            'TweetStim': 'plum',
+            'ExtractorResult': 'cornflowerblue'
+        }
 
         for elem in self._results:
             if not hasattr(elem, 'history'):
@@ -168,20 +181,23 @@ class Graph(object):
                 # Add nodes
                 source_from = log.parent[6] if log.parent else ''
                 s_node = hash((source_from, log[2]))
-                if s_node not in node_list:
-                    g.add_node(s_node, label=log[2], shape='ellipse')
+                g.add_node(s_node, label=log[2], shape='ellipse',
+                           style='filled', fillcolor=color_dict[log[2]])
 
+                style = 'filled'
+                style += ',dotted' if log.implicit else ''
+                t_color = ':'.join([color_dict[log[5]], color_dict[log[2]]])
                 t_node = hash((log[6], log[7]))
-                if t_node not in node_list:
-                    g.add_node(t_node, label=log[6], shape='box')
+                g.add_node(t_node, label=log[6], shape='box', style=style,
+                           fillcolor=t_color, gradientangle=90)
 
                 r_node = hash((log[6], log[5]))
-                if r_node not in node_list:
-                    g.add_node(r_node, label=log[5], shape='ellipse')
+                g.add_node(r_node, label=log[5], shape='ellipse',
+                           style='filled', fillcolor=color_dict[log[5]])
 
                 # Add edges
-                g.add_edge(s_node, t_node)
-                g.add_edge(t_node, r_node)
+                g.add_edge(s_node, t_node, style=style)
+                g.add_edge(t_node, r_node, style=style)
                 log = log.parent
 
         g.draw(filename, prog='dot')
@@ -265,7 +281,7 @@ class Graph(object):
         Graph(spec=filename).
 
         Args:
-            filename (str): path at which to write out the json file.
+            filename (str): Path at which to write out the json file.
         '''
         with open(filename, 'w') as outfile:
             json.dump(self.to_json(), outfile)

--- a/pliers/graph.py
+++ b/pliers/graph.py
@@ -80,7 +80,7 @@ class Graph(object):
             with open(spec) as spec_file:
                 self.add_nodes(json.load(spec_file)['roots'])
 
-    def add_nodes(self, nodes, parent=None):
+    def add_nodes(self, nodes, parent=None, mode='horizontal'):
         ''' Adds one or more nodes to the current graph.
 
         Args:
@@ -103,7 +103,20 @@ class Graph(object):
         '''
         for n in nodes:
             node_args = self._parse_node_args(n)
-            self.add_node(parent=parent, **node_args)
+            if mode == 'horizontal':
+                self.add_node(parent=parent, **node_args)
+            elif mode == 'vertical':
+                parent = self.add_node(parent=parent, return_node=True,
+                                       **node_args)
+            else:
+                raise ValueError("Invalid mode for adding nodes to a graph:"
+                                 "%s" % mode)
+
+    def add_chain(self, nodes, parent=None):
+        self.add_nodes(nodes, parent, 'vertical')
+
+    def add_children(self, nodes, parent=None):
+        self.add_nodes(nodes, parent, 'horizontal')
 
     def add_node(self, transformer, name=None, children=None, parent=None,
                  parameters={}, return_node=False):

--- a/pliers/graph.py
+++ b/pliers/graph.py
@@ -13,6 +13,20 @@ import json
 
 pgv = attempt_to_import('pygraphviz', 'pgv')
 
+COLOR_DICT = {
+    'AudioStim': '#f58231',
+    'ComplexTextStim': '#911eb4',
+    'TextStim': '#e6beff',
+    'VideoStim': '#ffe119',
+    'VideoFrameCollectionStim': 'yellow',
+    'VideoFrameStim': 'yellow',
+    'ImageStim': '#d2f53c',
+    'CompoundStim': 'pink',
+    'TranscribedAudioCompoundStim': 'violet',
+    'TweetStim': 'plum',
+    'ExtractorResult': 'honeydew2'
+}
+
 
 class Node(object):
 
@@ -245,20 +259,6 @@ class Graph(object):
 
         g = pgv.AGraph(directed=True)
 
-        color_dict = {
-            'AudioStim': 'aquamarine3',
-            'CompoundStim': 'cyan4',
-            'TranscribedAudioCompoundStim': 'cadetblue',
-            'ComplexTextStim': 'springgreen3',
-            'TextStim': 'springgreen2',
-            'VideoStim': 'red3',
-            'VideoFrameCollectionStim': 'tomato3',
-            'VideoFrameStim': 'salmon',
-            'ImageStim': 'indianred',
-            'TweetStim': 'plum',
-            'ExtractorResult': 'cornflowerblue'
-        }
-
         for elem in self._results:
             if not hasattr(elem, 'history'):
                 continue
@@ -269,18 +269,23 @@ class Graph(object):
                 source_from = log.parent[6] if log.parent else ''
                 s_node = hash((source_from, log[2]))
                 g.add_node(s_node, label=log[2], shape='ellipse',
-                           style='filled', fillcolor=color_dict[log[2]])
+                           style='filled', fillcolor=COLOR_DICT[log[2]])
 
                 style = 'filled'
                 style += ',dotted' if log.implicit else ''
-                t_color = ':'.join([color_dict[log[5]], color_dict[log[2]]])
+                if log[6].endswith('Extractor'):
+                    t_color = '#0082c8'
+                elif log[6].endswith('Filter'):
+                    t_color = '#e6194b'
+                else:
+                    t_color = '#3cb44b'
                 t_node = hash((log[6], log[7]))
                 g.add_node(t_node, label=log[6], shape='box', style=style,
-                           fillcolor=t_color, gradientangle=90)
+                           fillcolor=t_color)
 
                 r_node = hash((log[6], log[5]))
                 g.add_node(r_node, label=log[5], shape='ellipse',
-                           style='filled', fillcolor=color_dict[log[5]])
+                           style='filled', fillcolor=COLOR_DICT[log[5]])
 
                 # Add edges
                 g.add_edge(s_node, t_node, style=style)

--- a/pliers/graph.py
+++ b/pliers/graph.py
@@ -2,6 +2,7 @@
 of pliers Transformers. '''
 
 from pliers.extractors.base import merge_results
+from pliers.stimuli import __all__ as stim_list
 from pliers.transformers import get_transformer
 from pliers.utils import (listify, flatten, isgenerator, attempt_to_import,
                           verify_dependencies)
@@ -12,20 +13,7 @@ from collections import OrderedDict
 import json
 
 pgv = attempt_to_import('pygraphviz', 'pgv')
-
-COLOR_DICT = {
-    'AudioStim': '#f58231',
-    'ComplexTextStim': '#911eb4',
-    'TextStim': '#e6beff',
-    'VideoStim': '#ffe119',
-    'VideoFrameCollectionStim': 'yellow',
-    'VideoFrameStim': 'yellow',
-    'ImageStim': '#d2f53c',
-    'CompoundStim': 'pink',
-    'TranscribedAudioCompoundStim': 'violet',
-    'TweetStim': 'plum',
-    'ExtractorResult': 'honeydew2'
-}
+stim_list.insert(0, 'ExtractorResult')
 
 
 class Node(object):
@@ -258,6 +246,7 @@ class Graph(object):
                                "Try calling run() first.")
 
         g = pgv.AGraph(directed=True)
+        g.node_attr['colorscheme'] = 'set312'
 
         for elem in self._results:
             if not hasattr(elem, 'history'):
@@ -268,8 +257,10 @@ class Graph(object):
                 # Add nodes
                 source_from = log.parent[6] if log.parent else ''
                 s_node = hash((source_from, log[2]))
+                s_color = stim_list.index(log[2])
+                s_color = s_color % 12 + 1
                 g.add_node(s_node, label=log[2], shape='ellipse',
-                           style='filled', fillcolor=COLOR_DICT[log[2]])
+                           style='filled', fillcolor=s_color)
 
                 style = 'filled'
                 style += ',dotted' if log.implicit else ''
@@ -284,8 +275,10 @@ class Graph(object):
                            fillcolor=t_color)
 
                 r_node = hash((log[6], log[5]))
+                r_color = stim_list.index(log[5])
+                r_color = r_color % 12 + 1
                 g.add_node(r_node, label=log[5], shape='ellipse',
-                           style='filled', fillcolor=COLOR_DICT[log[5]])
+                           style='filled', fillcolor=r_color)
 
                 # Add edges
                 g.add_edge(s_node, t_node, style=style)

--- a/pliers/graph.py
+++ b/pliers/graph.py
@@ -164,9 +164,7 @@ class Graph(object):
                 continue
             log = elem.history
 
-            has_parent = True
-
-            while has_parent:
+            while log:
                 # Add nodes
                 source_from = log.parent[6] if log.parent else ''
                 s_node = hash((source_from, log[2]))
@@ -184,7 +182,6 @@ class Graph(object):
                 # Add edges
                 g.add_edge(s_node, t_node)
                 g.add_edge(t_node, r_node)
-                has_parent = log.parent
                 log = log.parent
 
         g.draw(filename, prog='dot')
@@ -256,11 +253,19 @@ class Graph(object):
         return kwargs
 
     def to_json(self):
+        ''' Returns the JSON representation of this graph. '''
         roots = []
         for r in self.roots:
             roots.append(r.to_json())
         return {'roots': roots}
 
     def save(self, filename):
+        ''' Writes the JSON representation of this graph to the provided
+        filename, such that the graph can be easily reconstructed using
+        Graph(spec=filename).
+
+        Args:
+            filename (str): path at which to write out the json file.
+        '''
         with open(filename, 'w') as outfile:
             json.dump(self.to_json(), outfile)

--- a/pliers/graph.py
+++ b/pliers/graph.py
@@ -122,6 +122,13 @@ class Graph(object):
             parent (Node): Optional parent node (i.e., the node containing the
                 pliers Transformer from which the to-be-created nodes receive
                 their inputs).
+            mode (str): Indicates the direction with which to add the new nodes
+                * horizontal: the nodes should each be added as a child of the
+                  'parent' argument (or a Graph root by default).
+                * vertical: the nodes should each be added in sequence with
+                  the first node being the child of the 'parnet' argument
+                  (a Graph root by default) and each subsequent node being
+                  the child of the previous node in the list.
         '''
         for n in nodes:
             node_args = self._parse_node_args(n)
@@ -135,9 +142,11 @@ class Graph(object):
                                  "%s" % mode)
 
     def add_chain(self, nodes, parent=None):
+        ''' An alias for add_nodes with the mode preset to 'vertical'. '''
         self.add_nodes(nodes, parent, 'vertical')
 
     def add_children(self, nodes, parent=None):
+        ''' An alias for add_nodes with the mode preset to 'horizontal'. '''
         self.add_nodes(nodes, parent, 'horizontal')
 
     def add_node(self, transformer, name=None, children=None, parent=None,

--- a/pliers/stimuli/base.py
+++ b/pliers/stimuli/base.py
@@ -212,8 +212,8 @@ class TransformationLog(_trans_log):
     def to_df(self):
         def _append_row(rows, history):
             rows.append(history[:-3])
-            if history[-2]:
-                _append_row(rows, history[-2])
+            if history.parent:
+                _append_row(rows, history.parent)
             return rows
         rows = _append_row([], self)[::-1]
         return pd.DataFrame(rows, columns=self._fields[:-3])

--- a/pliers/stimuli/base.py
+++ b/pliers/stimuli/base.py
@@ -164,7 +164,7 @@ def load_stims(source, dtype=None, fail_silently=False):
     return stims[0]
 
 
-def _log_transformation(source, result, trans=None):
+def _log_transformation(source, result, trans=None, implicit=False):
 
     if result is None or not config.get_option('log_transformations') or \
             (trans is not None and not trans._loggable):
@@ -189,12 +189,15 @@ def _log_transformation(source, result, trans=None):
     string = str(parent) if parent else values[2]
     string += '->%s/%s' % (values[6], values[5])
     values.extend([string, parent])
+    values.append(implicit)
     result.history = TransformationLog(*values)
     return result
 
+
 _trans_log = namedtuple('TransformationLog', "source_name source_file " +
                         "source_class result_name result_file result_class " +
-                        " transformer_class transformer_params string parent")
+                        " transformer_class transformer_params string " +
+                        "parent implicit")
 
 
 class TransformationLog(_trans_log):
@@ -208,9 +211,9 @@ class TransformationLog(_trans_log):
 
     def to_df(self):
         def _append_row(rows, history):
-            rows.append(history[:-2])
-            if history[-1]:
-                _append_row(rows, history[-1])
+            rows.append(history[:-3])
+            if history[-2]:
+                _append_row(rows, history[-2])
             return rows
         rows = _append_row([], self)[::-1]
-        return pd.DataFrame(rows, columns=self._fields[:-2])
+        return pd.DataFrame(rows, columns=self._fields[:-3])

--- a/pliers/tests/test_graph.py
+++ b/pliers/tests/test_graph.py
@@ -188,7 +188,7 @@ def test_big_pipeline():
         VibranceExtractor(), 'BrightnessExtractor',
     ])]
     audio_nodes = [(VideoToAudioConverter(), [
-        WitTranscriptionConverter(), 'LengthExtractor'],
+        (WitTranscriptionConverter(), ['LengthExtractor'])],
         'video_to_audio')]
     graph = Graph()
     graph.add_nodes(visual_nodes)
@@ -350,6 +350,7 @@ def test_save_graph():
     graph.save(filename)
     assert os.path.exists(filename)
     same_graph = Graph(spec=filename)
+    os.remove(filename)
     assert graph.to_json() == same_graph.to_json()
     img = join(get_test_data_path(), 'image', 'button.jpg')
     res = same_graph.run(img)

--- a/pliers/transformers/base.py
+++ b/pliers/transformers/base.py
@@ -141,7 +141,7 @@ class Transformer(with_metaclass(ABCMeta)):
             if converter:
                 _old_stim = stim
                 stim = converter.transform(stim)
-                stim = _log_transformation(_old_stim, stim, converter)
+                stim = _log_transformation(_old_stim, stim, converter, True)
             else:
                 msg = ("Transformers of type %s can only be applied to stimuli"
                        " of type(s) %s (not type %s), and no applicable "


### PR DESCRIPTION
Improvements to the Graph API including:
- Allowing graphs to return stims (when calling `.run` with `merge=False`), which is useful for creating `Graph`s for preprocessing pipelines composed of only `Filter`s and `Converter`s
- `to_json` and `save` methods for graph objects for simple serialization and loading
- Ability to add linear chains (sequence of transformers) to a `Graph` using the `add_nodes` method with `mode='vertical'` or the `add_chain` method
- Style updates to the `draw` method, including representing implicit transformations with dotted borders and color coding stimuli and transformers
  - The latter is still a WIP as the color coding needs work aesthetically


Resolves #249
Resolves #225
Resolves #224