### PR TITLE
Fix support for converters to updater

### DIFF
--- a/pliers/tests/test_updater.py
+++ b/pliers/tests/test_updater.py
@@ -15,9 +15,10 @@ def test_updater():
 
     # Change value in datastore
     ds = pd.read_csv(datastore_file)
-    ds.iloc[1, 3] = 1
+    ds.iloc[1, 1:] = 1
     ds.to_csv(datastore_file, index=False)
 
     results = check_updates(transformers, datastore=datastore_file)
-    assert results['transformers'] == [('TesseractConverter', {})]
-    assert len(results['mismatches']) == 1
+    for j in results['transformers']:
+        assert j in transformers
+    assert len(results['mismatches']) == 198

--- a/pliers/tests/test_updater.py
+++ b/pliers/tests/test_updater.py
@@ -4,14 +4,13 @@ import pandas as pd
 
 def test_updater():
     datastore_file = NamedTemporaryFile().name
+    transformers = [('BrightnessExtractor', {}), ('TesseractConverter', {})]
     # Run updater once
-    results = check_updates([('BrightnessExtractor', {})],
-                            datastore=datastore_file)
+    results = check_updates(transformers, datastore=datastore_file)
     assert results == {'transformers': [], 'mismatches': []}
 
     # Run again with same values
-    results = check_updates([('BrightnessExtractor', {})],
-                            datastore=datastore_file)
+    results = check_updates(transformers, datastore=datastore_file)
     assert results == {'transformers': [], 'mismatches': []}
 
     # Change value in datastore
@@ -19,7 +18,6 @@ def test_updater():
     ds.iloc[1, 3] = 1
     ds.to_csv(datastore_file, index=False)
 
-    results = check_updates([('BrightnessExtractor', {})],
-                            datastore=datastore_file)
-    assert results['transformers'] == [('BrightnessExtractor', {})]
+    results = check_updates(transformers, datastore=datastore_file)
+    assert results['transformers'] == [('TesseractConverter', {})]
     assert len(results['mismatches']) == 1

--- a/pliers/transformers/base.py
+++ b/pliers/transformers/base.py
@@ -168,7 +168,8 @@ class Transformer(with_metaclass(ABCMeta)):
             msg = ("Transformer of class %s requires multiple mandatory "
                    "inputs, so the passed input Stim must be a CompoundStim"
                    "--which it isn't." % self.__class__.__name__)
-            raise ValueError(msg)
+            logging.warning(msg)
+            return False
 
         return isinstance(stim, mandatory) or (not mandatory and
                                                isinstance(stim, optional))

--- a/pliers/utils/updater.py
+++ b/pliers/utils/updater.py
@@ -8,18 +8,14 @@ from os.path import realpath, join, dirname, exists, expanduser
 from pliers.stimuli import load_stims
 from pliers.transformers import get_transformer
 import hashlib
-
+import pickle
 
 def hash_data(data, blocksize=65536):
     """" Hashes list of data, strings or data """
-    if isinstance(data, str):
-        data = [data.encode('utf-8')]
-    if not isinstance(data, list):
-        data = [data]
+    data = pickle.dumps(data)
 
     hasher = hashlib.sha1()
-    for i in data:
-        hasher.update(i)
+    hasher.update(data)
 
     return hasher.hexdigest()
 

--- a/pliers/utils/updater.py
+++ b/pliers/utils/updater.py
@@ -6,8 +6,6 @@ import pandas as pd
 import numpy as np
 from os.path import realpath, join, dirname, exists, expanduser
 from pliers.stimuli import load_stims
-from pliers.converters import Converter
-from pliers.filters.base import Filter
 from pliers.transformers import get_transformer
 import hashlib
 
@@ -16,7 +14,7 @@ def hash_data(data, blocksize=65536):
     """" Hashes list of data, strings or data """
     if isinstance(data, str):
         data = [data.encode('utf-8')]
-    elif not isinstance(data, list):
+    if not isinstance(data, list):
         data = [data]
 
     hasher = hashlib.sha1()
@@ -59,12 +57,11 @@ def check_updates(transformers, datastore=None, stimuli=None):
                 res = trans.transform(stim)
 
                 try: # Add iterable
-                    res = [res._data for r in res]
+                    res = [getattr(res, '_data', res.data) for r in res]
                 except TypeError:
-                    res = res._data
+                    res = getattr(res, '_data', res.data)
 
-                res = hash_data(res) if isinstance(
-                    trans, (Converter, Filter)) else res[0][0]
+                res = hash_data(res)
 
                 results["{}.{}".format(trans.__hash__(), stim.name)] = [res]
 


### PR DESCRIPTION
Updater was failing due to a change in the structure of `ExtractorResult` and differences between Convertors and Extractors.

In addition, only the first result may have been checked in extractors, so now I'm hashing all results including those from Extractors