### PR TITLE
Setting Google default batch size to 1

### DIFF
--- a/pliers/transformers/api/google.py
+++ b/pliers/transformers/api/google.py
@@ -53,7 +53,7 @@ class GoogleAPITransformer(Transformer, EnvironmentKeyMixin):
 class GoogleVisionAPITransformer(BatchTransformerMixin, GoogleAPITransformer):
 
     api_name = 'vision'
-    _batch_size = 10
+    _batch_size = 1
 
     def _query_api(self, request):
         request_obj = self.service.images() \


### PR DESCRIPTION
To prevent hitting usage quotas, until we can figure out a best default.
@adelavega 
@tyarkoni 