### PR TITLE
Append _ to protected names in to_df

### DIFF
--- a/pliers/extractors/base.py
+++ b/pliers/extractors/base.py
@@ -124,6 +124,11 @@ class ExtractorResult(object):
         durations = np.nan if self.duration is None else self.duration
         orders = np.nan if self.order is None else self.order
 
+        # If any features clash with protected keys, append underscore
+        protected = ['onset', 'order', 'duration', 'extractor', 'stim_name', \
+                     'class', 'filename', 'history', 'source_file']
+        df = df.rename(columns={k: k + '_' for k in protected})
+
         index_cols = []
 
         # Generally we leave it to Extractors to properly track the number of

--- a/pliers/tests/extractors/test_extractors.py
+++ b/pliers/tests/extractors/test_extractors.py
@@ -1,5 +1,5 @@
 from os.path import join
-from ..utils import get_test_data_path, DummyExtractor
+from ..utils import get_test_data_path, DummyExtractor, ClashingFeatureExtractor
 from pliers.extractors import (LengthExtractor,
                                BrightnessExtractor,
                                SharpnessExtractor,
@@ -37,6 +37,17 @@ def test_implicit_stim_iteration():
     assert len(results) == 2
     assert isinstance(results[0], ExtractorResult)
 
+def test_clashing_key_rename():
+    image_dir = join(get_test_data_path(), 'image')
+    stim1 = ImageStim(join(image_dir, 'apple.jpg'))
+
+    cf = ClashingFeatureExtractor()
+    results = cf.transform(stim1)
+    df = results.to_df()
+    expected_keys = ['order', 'duration', 'onset', 'object_id',
+                     'feature_1', 'feature_2', 'order_']
+    for k in expected_keys:
+        assert k in df.columns
 
 def test_implicit_stim_conversion():
     image_dir = join(get_test_data_path(), 'image')

--- a/pliers/tests/utils.py
+++ b/pliers/tests/utils.py
@@ -4,7 +4,7 @@ from pliers.extractors.base import Extractor, ExtractorResult
 from pliers.transformers import BatchTransformerMixin
 import numpy as np
 from copy import deepcopy
-
+import pandas as pd
 
 def get_test_data_path():
     """Returns the path to test datasets """
@@ -50,3 +50,11 @@ class DummyBatchExtractor(BatchTransformerMixin, Extractor):
         for s in stims:
             results.append(ExtractorResult([[len(s.name)]], s, self))
         return results
+
+class ClashingFeatureExtractor(DummyExtractor):
+
+    def _to_df(self, result, **kwargs):
+        names = ['feature_{}'.format(i+1) for i in range(result._data.shape[1] - 1)]
+        names += ['order'] # Clashing feature name
+
+        return pd.DataFrame(result._data, columns=names)


### PR DESCRIPTION
Addresses #274 

Waiting on tests. 

Started by only appending `_` to `order`, `duration` and `onset`

Question is if this change should only affect `to_df` or if similar changes should be made throughout pliers. If individual extractors implement `to_df`, do they also need to be changed?

I'm also guessing there will be a lot of downstream effects of changing these column names. 