### PR TITLE
Batch caching

### DIFF
--- a/pliers/extractors/api/clarifai.py
+++ b/pliers/extractors/api/clarifai.py
@@ -47,7 +47,8 @@ class ClarifaiAPIExtractor(APITransformer, BatchTransformerMixin,
     VERSION = '1.0'
 
     def __init__(self, api_key=None, model='general-v1.3', min_value=None,
-                 max_concepts=None, select_concepts=None, rate_limit=None):
+                 max_concepts=None, select_concepts=None, rate_limit=None,
+                 batch_size=None):
         verify_dependencies(['clarifai_client'])
         if api_key is None:
             try:
@@ -72,7 +73,8 @@ class ClarifaiAPIExtractor(APITransformer, BatchTransformerMixin,
             select_concepts = listify(select_concepts)
             self.select_concepts = [clarifai_client.Concept(concept_name=n)
                                     for n in select_concepts]
-        super(ClarifaiAPIExtractor, self).__init__(rate_limit=rate_limit)
+        super(ClarifaiAPIExtractor, self).__init__(rate_limit=rate_limit,
+                                                   batch_size=batch_size)
 
     @property
     def api_keys(self):

--- a/pliers/extractors/api/indico.py
+++ b/pliers/extractors/api/indico.py
@@ -30,7 +30,8 @@ class IndicoAPIExtractor(APITransformer, BatchTransformerMixin, Extractor):
     _env_keys = 'INDICO_APP_KEY'
     VERSION = '1.0'
 
-    def __init__(self, api_key=None, models=None, rate_limit=None):
+    def __init__(self, api_key=None, models=None, rate_limit=None,
+                 batch_size=None):
         verify_dependencies(['indicoio'])
         if api_key is None:
             try:
@@ -54,7 +55,8 @@ class IndicoAPIExtractor(APITransformer, BatchTransformerMixin, Extractor):
         self.model_names = models
         self.models = [getattr(indicoio, model) for model in models]
         self.names = models
-        super(IndicoAPIExtractor, self).__init__(rate_limit=rate_limit)
+        super(IndicoAPIExtractor, self).__init__(rate_limit=rate_limit,
+                                                 batch_size=batch_size)
 
     @property
     def api_keys(self):
@@ -100,12 +102,14 @@ class IndicoAPITextExtractor(TextExtractor, IndicoAPIExtractor):
     sentiment extraction.
     '''
 
-    def __init__(self, api_key=None, models=None, rate_limit=None):
+    def __init__(self, api_key=None, models=None, rate_limit=None,
+                 batch_size=None):
         verify_dependencies(['indicoio'])
         self.allowed_models = indicoio.TEXT_APIS.keys()
         super(IndicoAPITextExtractor, self).__init__(api_key=api_key,
                                                      models=models,
-                                                     rate_limit=rate_limit)
+                                                     rate_limit=rate_limit,
+                                                     batch_size=batch_size)
 
 
 class IndicoAPIImageExtractor(ImageExtractor, IndicoAPIExtractor):
@@ -114,9 +118,11 @@ class IndicoAPIImageExtractor(ImageExtractor, IndicoAPIExtractor):
     facial emotion recognition or content filtering.
     '''
 
-    def __init__(self, api_key=None, models=None, rate_limit=None):
+    def __init__(self, api_key=None, models=None, rate_limit=None,
+                 batch_size=None):
         verify_dependencies(['indicoio'])
         self.allowed_models = indicoio.IMAGE_APIS.keys()
         super(IndicoAPIImageExtractor, self).__init__(api_key=api_key,
                                                       models=models,
-                                                      rate_limit=rate_limit)
+                                                      rate_limit=rate_limit,
+                                                      batch_size=batch_size)

--- a/pliers/extractors/text.py
+++ b/pliers/extractors/text.py
@@ -272,15 +272,16 @@ class TextVectorizerExtractor(BatchTransformerMixin, TextExtractor):
     _log_attributes = ('vectorizer',)
     _batch_size = sys.maxsize
 
-    def __init__(self, vectorizer=None, *args, **kwargs):
+    def __init__(self, vectorizer=None, *vectorizer_args, **vectorizer_kwargs):
         verify_dependencies(['sklearn_text'])
         if isinstance(vectorizer, sklearn_text.VectorizerMixin):
             self.vectorizer = vectorizer
         elif isinstance(vectorizer, str):
             vec = getattr(sklearn_text, vectorizer)
-            self.vectorizer = vec(*args, **kwargs)
+            self.vectorizer = vec(*vectorizer_args, **vectorizer_kwargs)
         else:
-            self.vectorizer = sklearn_text.CountVectorizer(*args, **kwargs)
+            self.vectorizer = sklearn_text.CountVectorizer(*vectorizer_args,
+                                                           **vectorizer_kwargs)
         super(TextVectorizerExtractor, self).__init__()
 
     def _extract(self, stims):

--- a/pliers/tests/extractors/api/test_clarifai_extractors.py
+++ b/pliers/tests/extractors/api/test_clarifai_extractors.py
@@ -3,10 +3,9 @@ from ...utils import get_test_data_path
 from pliers import config
 from pliers.extractors import ClarifaiAPIExtractor
 from pliers.extractors.base import merge_results
-from pliers.stimuli import ImageStim, VideoStim
+from pliers.stimuli import ImageStim
 import numpy as np
 import pytest
-import time
 
 IMAGE_DIR = join(get_test_data_path(), 'image')
 
@@ -56,14 +55,15 @@ def test_clarifai_api_extractor_large():
     config.set_option('large_job', 1)
 
     ext = ClarifaiAPIExtractor()
-    images = [ImageStim(join(get_test_data_path(), 'image', 'apple.jpg'))] * 2
+    images = [ImageStim(join(IMAGE_DIR, 'apple.jpg')),
+              ImageStim(join(IMAGE_DIR, 'obama.jpg'))]
     with pytest.raises(ValueError):
         merge_results(ext.transform(images))
 
     config.set_option('allow_large_jobs', True)
     results = merge_results(ext.transform(images))
     assert 'ClarifaiAPIExtractor#apple' in results.columns
-    assert results.shape == (1, 29)  # not 2 cause all the same instance
+    assert results.shape == (2, 49)
 
     config.set_option('allow_large_jobs', default)
     config.set_option('large_job', default_large)

--- a/pliers/tests/extractors/api/test_indico_extractors.py
+++ b/pliers/tests/extractors/api/test_indico_extractors.py
@@ -96,7 +96,8 @@ def test_indico_api_extractor_large():
 
     ext = IndicoAPIImageExtractor(models=['fer'])
 
-    images = [ImageStim(join(IMAGE_DIR, 'apple.jpg'))] * 2
+    images = [ImageStim(join(IMAGE_DIR, 'apple.jpg')),
+              ImageStim(join(IMAGE_DIR, 'obama.jpg'))]
     with pytest.raises(ValueError):
         merge_results(ext.transform(images))
 
@@ -104,7 +105,7 @@ def test_indico_api_extractor_large():
 
     results = merge_results(ext.transform(images))
     assert 'IndicoAPIImageExtractor#fer_Neutral' in results.columns
-    assert results.shape == (1, 15)  # not 2 rows cause all the same instance
+    assert results.shape == (2, 15)
 
     config.set_option('allow_large_jobs', default)
     config.set_option('large_job', default_large)
@@ -114,8 +115,7 @@ def test_indico_api_extractor_large():
 def test_indico_api_extractor_rate_limit():
     stim = ImageStim(join(IMAGE_DIR, 'apple.jpg'))
     stim2 = ImageStim(join(IMAGE_DIR, 'obama.jpg'))
-    ext = IndicoAPIImageExtractor(models=['fer'], rate_limit=5)
-    ext._batch_size = 1
+    ext = IndicoAPIImageExtractor(models=['image_features'], rate_limit=5, batch_size=1)
     t1 = time.time()
     ext.transform([stim, stim2])
     t2 = time.time()

--- a/pliers/transformers/api/google.py
+++ b/pliers/transformers/api/google.py
@@ -28,7 +28,7 @@ class GoogleAPITransformer(APITransformer):
     _log_attributes = ('discovery_file', 'api_version')
 
     def __init__(self, discovery_file=None, api_version='v1', max_results=100,
-                 num_retries=3, rate_limit=None):
+                 num_retries=3, rate_limit=None, **kwargs):
         verify_dependencies(['googleapiclient', 'oauth_client'])
         if discovery_file is None:
             if 'GOOGLE_APPLICATION_CREDENTIALS' not in os.environ:
@@ -52,7 +52,8 @@ class GoogleAPITransformer(APITransformer):
         self.max_results = max_results
         self.num_retries = num_retries
         self.api_version = api_version
-        super(GoogleAPITransformer, self).__init__(rate_limit=rate_limit)
+        super(GoogleAPITransformer, self).__init__(rate_limit=rate_limit,
+                                                   **kwargs)
 
     @property
     def api_keys(self):
@@ -66,6 +67,15 @@ class GoogleVisionAPITransformer(GoogleAPITransformer, BatchTransformerMixin):
 
     api_name = 'vision'
     _batch_size = 1
+
+    def __init__(self, discovery_file=None, api_version='v1', max_results=100,
+                 num_retries=3, rate_limit=None, batch_size=None):
+        super(GoogleVisionAPITransformer, self).__init__(discovery_file=discovery_file,
+                                                         api_version=api_version,
+                                                         max_results=max_results,
+                                                         num_retries=num_retries,
+                                                         rate_limit=rate_limit,
+                                                         batch_size=batch_size)
 
     def _query_api(self, request):
         request_obj = self.service.images() \

--- a/pliers/transformers/base.py
+++ b/pliers/transformers/base.py
@@ -240,10 +240,13 @@ class BatchTransformerMixin(Transformer):
             non_cached = []
             for stim in batch:
                 key = hash((hash(self), hash(stim)))
+                # If using the cache, only transform stims that aren't in the
+                # cache and haven't already appeared in the batch
                 if not (use_cache and (key in _cache or key in target_inds)):
                     target_inds[key] = len(non_cached)
                     non_cached.append(stim)
 
+            # _transform will likely fail if given an empty list
             if len(non_cached) > 0:
                 batch_results = self._transform(non_cached, *args, **kwargs)
             else:
@@ -251,6 +254,7 @@ class BatchTransformerMixin(Transformer):
 
             for i, stim in enumerate(batch):
                 key = hash((hash(self), hash(stim)))
+                # Use the target index to get the result from batch_results
                 if key in target_inds:
                     result = batch_results[target_inds[key]]
                     result = _log_transformation(stim, result, self)
@@ -260,6 +264,7 @@ class BatchTransformerMixin(Transformer):
                             result = list(result)
                         _cache[key] = result
                     results.append(result)
+                # Otherwise, the result should be in the cache
                 else:
                     results.append(_cache[key])
         return results


### PR DESCRIPTION
Implementation of caching in `BatchTransformerMixin`. This required custom code in `pliers/transformers/base.py` in the `_iterate` method that kept track of repeated elements in a batch or elements already in the cache. 

Also added to some docstrings and the `batch_size` argument everywhere explicitly.

Resolves #272 