### PR TITLE
Various bug fixes and minor cleanups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ install:
 before_script:
 - python -m pliers.support.download
 script:
-- py.test -m --pyargs pliers --cov-report term-missing --cov=pliers
+- py.test --pyargs pliers --cov-report term-missing --cov=pliers
 after_success:
 - coveralls
 before_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ install:
 before_script:
 - python -m pliers.support.download
 script:
-- py.test --pyargs pliers --cov-report term-missing --cov=pliers
+- py.test -m "not long_test" --pyargs pliers --cov-report term-missing --cov=pliers
 after_success:
 - coveralls
 before_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ install:
 before_script:
 - python -m pliers.support.download
 script:
-- py.test -m "not long_test" --pyargs pliers --cov-report term-missing --cov=pliers
+- py.test -m --pyargs pliers --cov-report term-missing --cov=pliers
 after_success:
 - coveralls
 before_cache:

--- a/pliers/converters/api/google.py
+++ b/pliers/converters/api/google.py
@@ -19,9 +19,8 @@ class GoogleSpeechAPIConverter(GoogleAPITransformer, AudioToTextConverter):
         language_code (str): The language of the supplied AudioStim.
         profanity_filter (bool): If set to True, will ask Google to try and
             filter out profanity from the resulting Text.
-        speech_contexts (list): A list of a list of favored phrases or words
-            to assist the API. The inner list is a sequence of word tokens,
-            each outer element is a potential context.
+        speech_contexts (list): A list of favored phrases or words
++            to assist the API.
         discovery_file (str): path to discovery file containing Google
             application credentials.
         api_version (str): API version to use.
@@ -63,7 +62,7 @@ class GoogleSpeechAPIConverter(GoogleAPITransformer, AudioToTextConverter):
         os.remove(tmp)
 
         if self.speech_contexts:
-            speech_contexts = [{'phrases': c} for c in self.speech_contexts]
+            speech_contexts = [{'phrases': self.speech_contexts}]
         else:
             speech_contexts = []
         request = {

--- a/pliers/filters/text.py
+++ b/pliers/filters/text.py
@@ -139,8 +139,11 @@ class PunctuationRemovalFilter(TokenRemovalFilter):
 
     ''' Removes punctuation from a TextStim. '''
 
-    def __init__(self, tokens=string.punctuation):
-        super(PunctuationRemovalFilter, self).__init__(tokens)
+    def _filter(self, stim):
+        text = stim.text
+        for c in string.punctuation:
+            text = text.replace(c, '')
+        return TextStim(stim.filename, text)
 
 
 class LowerCasingFilter(TextFilter):

--- a/pliers/filters/text.py
+++ b/pliers/filters/text.py
@@ -2,6 +2,7 @@
 
 import nltk
 import string
+import re
 
 from six import string_types
 from nltk import stem
@@ -135,14 +136,13 @@ class TokenRemovalFilter(TextFilter):
         return TextStim(stim.filename, text)
 
 
-class PunctuationRemovalFilter(TokenRemovalFilter):
+class PunctuationRemovalFilter(TextFilter):
 
     ''' Removes punctuation from a TextStim. '''
 
     def _filter(self, stim):
-        text = stim.text
-        for c in string.punctuation:
-            text = text.replace(c, '')
+        pattern = '[%s]' % re.escape(string.punctuation)
+        text = re.sub(pattern, '', stim.text)
         return TextStim(stim.filename, text)
 
 

--- a/pliers/filters/video.py
+++ b/pliers/filters/video.py
@@ -1,9 +1,13 @@
 ''' Filters that operate on TextStim inputs. '''
 
 from pliers.stimuli.video import VideoStim, VideoFrameCollectionStim
+from pliers.utils import attempt_to_import, verify_dependencies
 from .base import Filter, TemporalTrimmingFilter
 
 import numpy as np
+
+
+cv2 = attempt_to_import('cv2')
 
 
 class VideoFilter(Filter):
@@ -13,14 +17,7 @@ class VideoFilter(Filter):
     _input_type = VideoStim
 
 
-class VideoFrameFilter(Filter):
-
-    ''' Base class for all VideoFrameFilters. '''
-
-    _input_type = VideoFrameCollectionStim
-
-
-class FrameSamplingFilter(VideoFrameFilter):
+class FrameSamplingFilter(Filter):
 
     ''' Samples frames from video stimuli, to improve efficiency.
 
@@ -31,6 +28,7 @@ class FrameSamplingFilter(VideoFrameFilter):
          with the next frame
     '''
 
+    _input_type = VideoFrameCollectionStim
     _log_attributes = ('every', 'hertz', 'top_n')
     VERSION = '1.0'
 
@@ -56,7 +54,7 @@ class FrameSamplingFilter(VideoFrameFilter):
             new_idx = np.arange(0, video.n_frames, interval).astype(int)
             new_idx = list(new_idx)
         elif self.top_n is not None:
-            import cv2
+            verify_dependencies(['cv2'])
             diffs = []
             for i, img in enumerate(video.frames):
                 if i == 0:

--- a/pliers/filters/video.py
+++ b/pliers/filters/video.py
@@ -57,6 +57,7 @@ class FrameSamplingFilter(VideoFilter):
         frame_index = sorted(list(set(video.frame_index).intersection(new_idx)))
 
         return VideoFrameCollectionStim(filename=video.filename,
+                                        clip=video.clip,
                                         frame_index=frame_index)
 
 

--- a/pliers/filters/video.py
+++ b/pliers/filters/video.py
@@ -1,17 +1,26 @@
 ''' Filters that operate on TextStim inputs. '''
 
-from pliers.stimuli.video import VideoFrameCollectionStim
+from pliers.stimuli.video import VideoStim, VideoFrameCollectionStim
 from .base import Filter, TemporalTrimmingFilter
+
+import numpy as np
 
 
 class VideoFilter(Filter):
 
     ''' Base class for all VideoFilters. '''
 
+    _input_type = VideoStim
+
+
+class VideoFrameFilter(Filter):
+
+    ''' Base class for all VideoFrameFilters. '''
+
     _input_type = VideoFrameCollectionStim
 
 
-class FrameSamplingFilter(VideoFilter):
+class FrameSamplingFilter(VideoFrameFilter):
 
     ''' Samples frames from video stimuli, to improve efficiency.
 
@@ -36,11 +45,16 @@ class FrameSamplingFilter(VideoFilter):
         super(FrameSamplingFilter, self).__init__()
 
     def _filter(self, video):
+        if not isinstance(video, VideoStim):
+            raise TypeError('Currently, frame sampling is only supported for '
+                            'complete VideoStim inputs.')
+
         if self.every is not None:
-            new_idx = range(int(video.fps * video.clip.duration))[::self.every]
+            new_idx = range(video.n_frames)[::self.every]
         elif self.hertz is not None:
-            interval = int(video.fps / self.hertz)
-            new_idx = range(int(video.fps * video.clip.duration))[::interval]
+            interval = video.fps / float(self.hertz)
+            new_idx = np.arange(0, video.n_frames, interval).astype(int)
+            new_idx = list(new_idx)
         elif self.top_n is not None:
             import cv2
             diffs = []
@@ -48,17 +62,16 @@ class FrameSamplingFilter(VideoFilter):
                 if i == 0:
                     last = img
                     continue
-                diffs.append(sum(cv2.sumElems(cv2.absdiff(last.data, img.data))))
+                pixel_diffs = cv2.sumElems(cv2.absdiff(last.data, img.data))
+                diffs.append(sum(pixel_diffs))
                 last = img
             new_idx = sorted(range(len(diffs)),
                              key=lambda i: diffs[i],
                              reverse=True)[:self.top_n]
 
-        frame_index = sorted(list(set(video.frame_index).intersection(new_idx)))
-
         return VideoFrameCollectionStim(filename=video.filename,
                                         clip=video.clip,
-                                        frame_index=frame_index)
+                                        frame_index=new_idx)
 
 
 class VideoTrimmingFilter(TemporalTrimmingFilter, VideoFilter):

--- a/pliers/stimuli/audio.py
+++ b/pliers/stimuli/audio.py
@@ -34,13 +34,13 @@ class AudioStim(Stim):
             filename = url
         self.filename = filename
 
-        self.sampling_rate = sampling_rate
-        if not self.sampling_rate:
-            self.sampling_rate = self.get_sampling_rate(self.filename)
-
         if clip:
+            self.sampling_rate = clip.fps
             self.clip = clip
         else:
+            self.sampling_rate = sampling_rate
+            if not self.sampling_rate:
+                self.sampling_rate = self.get_sampling_rate(self.filename)
             self._load_clip()
 
         # Small default buffer isn't ideal, but moviepy has persistent issues

--- a/pliers/stimuli/text.py
+++ b/pliers/stimuli/text.py
@@ -148,7 +148,7 @@ class ComplexTextStim(Stim):
                 elem = TextStim(filename, r['text'], r['onset'], duration)
             self._elements.append(elem)
 
-    def save(self, path, format=None):
+    def save(self, path):
         if path.endswith('srt'):
             verify_dependencies(['pysrt'])
             from pysrt import SubRipFile, SubRipItem

--- a/pliers/stimuli/text.py
+++ b/pliers/stimuli/text.py
@@ -5,7 +5,10 @@ import pandas as pd
 from six import string_types
 from six.moves.urllib.request import urlopen
 from pliers.support.decorators import requires_nltk_corpus
+from pliers.utils import attempt_to_import, verify_dependencies
 from .base import Stim
+
+pysrt = attempt_to_import('pysrt')
 
 
 class TextStim(Stim):
@@ -147,15 +150,15 @@ class ComplexTextStim(Stim):
 
     def save(self, path, format=None):
         if path.endswith('srt'):
-            from pysrt import SubRipFile, SubRipItem, SubRipTime
+            verify_dependencies(['pysrt'])
+            from pysrt import SubRipFile, SubRipItem
             from datetime import time
 
             out = SubRipFile()
             for elem in self._elements:
                 start = time(*self._to_tup(elem.onset))
                 end = time(*self._to_tup(elem.onset + elem.duration))
-                item = SubRipItem(0, start, end, elem.text)
-                out.append(item)
+                out.append(SubRipItem(0, start, end, elem.text))
             out.save(path)
         else:
             with open(path, 'w') as f:
@@ -166,7 +169,7 @@ class ComplexTextStim(Stim):
                                                   elem.duration))
 
     def _from_srt(self, filename):
-        import pysrt
+        verify_dependencies(['pysrt'])
 
         data = pysrt.open(filename)
         list_ = [[] for _ in data]

--- a/pliers/stimuli/text.py
+++ b/pliers/stimuli/text.py
@@ -195,8 +195,10 @@ class ComplexTextStim(Stim):
         """ Iterate text elements. """
         for elem in self._elements:
             offset = 0.0 if self.onset is None else self.onset
-            elem.onset = offset if elem.onset is None else offset + elem.onset
-            yield elem
+            # Calculate element onset relative to this stimulus
+            rel_onset = offset if elem.onset is None else offset + elem.onset
+            yield TextStim(elem.filename, elem.text, rel_onset, elem.duration,
+                           elem.order)
 
     def _to_tup(self, sec):
         hours = int(sec / 3600)

--- a/pliers/stimuli/video.py
+++ b/pliers/stimuli/video.py
@@ -20,18 +20,19 @@ class VideoFrameStim(ImageStim):
         data (ndarray): Optional numpy array to initialize the image from.
     '''
 
-    def __init__(self, video, frame_num, duration=None, filename=None,
-                 data=None):
+    def __init__(self, video, frame_num, duration=None, data=None):
         self.video = video
         self.frame_num = frame_num
         spf = 1. / video.fps
         duration = spf if duration is None else duration
         onset = frame_num * spf
+        if data is None:
+            data = self.video.clip.get_frame(onset)
         if video.onset:
             onset += video.onset
-        super(VideoFrameStim, self).__init__(filename, onset, duration, data)
-        if data is None:
-            self.data = self.video.get_frame(index=frame_num).data
+        super(VideoFrameStim, self).__init__(onset=onset,
+                                             duration=duration,
+                                             data=data)
         self.name += 'frame[%s]' % frame_num
 
 

--- a/pliers/stimuli/video.py
+++ b/pliers/stimuli/video.py
@@ -132,7 +132,7 @@ class VideoFrameCollectionStim(Stim):
             frames.
         '''
         # IMPORTANT WARNING: saves entire source video
-        self.clip.write_videofile(path)
+        self.clip.write_videofile(path, audio_fps=self.clip.audio.fps)
 
 
 class VideoStim(VideoFrameCollectionStim):

--- a/pliers/stimuli/video.py
+++ b/pliers/stimuli/video.py
@@ -69,10 +69,9 @@ class VideoFrameCollectionStim(Stim):
         self.height = self.clip.h
         if frame_index:
             self.frame_index = frame_index
-            duration = len(frame_index) / float(self.fps)
         else:
             self.frame_index = range(int(ceil(self.fps * self.clip.duration)))
-            duration = self.clip.duration
+        duration = self.clip.duration
         self.n_frames = len(self.frame_index)
         super(VideoFrameCollectionStim, self).__init__(filename,
                                                        onset=onset,
@@ -92,15 +91,12 @@ class VideoFrameCollectionStim(Stim):
     def frames(self):
         return (f for f in self)
 
-    def get_frame(self, index=None, onset=None):
+    def get_frame(self, index):
         ''' Get video frame at the specified index.
 
         Args:
             index (int): Positional index of the desired frame.
-            onset (float): Onset (in seconds) of the desired frame.
         '''
-        if onset:
-            index = int(onset * self.fps)
 
         frame_num = self.frame_index[index]
         onset = float(frame_num) / self.fps
@@ -158,3 +154,16 @@ class VideoStim(VideoFrameCollectionStim):
                                         onset=onset,
                                         url=url,
                                         clip=clip)
+
+    def get_frame(self, index=None, onset=None):
+        ''' Overrides the default behavior by giving access to the onset
+        argument.
+
+        Args:
+            index (int): Positional index of the desired frame.
+            onset (float): Onset (in seconds) of the desired frame.
+        '''
+        if onset:
+            index = int(onset * self.fps)
+
+        return super(VideoStim, self).get_frame(index)

--- a/pliers/tests/extractors/api/test_google_extractors.py
+++ b/pliers/tests/extractors/api/test_google_extractors.py
@@ -245,6 +245,7 @@ def test_google_video_api_extractor2(caplog):
         assert 'UNLIKELY' in result['pornographyLikelihood'][0]
 
 
+@pytest.mark.long_test
 @pytest.mark.requires_payment
 @pytest.mark.skipif("'GOOGLE_APPLICATION_CREDENTIALS' not in os.environ")
 def test_google_video_api_label_extractor(caplog):
@@ -286,6 +287,7 @@ def test_google_video_api_label_extractor(caplog):
         assert result['clock'][1] > 0.5 or result['clock'][0] > 0.5
 
 
+@pytest.mark.long_test
 @pytest.mark.requires_payment
 @pytest.mark.skipif("'GOOGLE_APPLICATION_CREDENTIALS' not in os.environ")
 def test_google_video_api_shot_extractor(caplog):
@@ -317,6 +319,7 @@ def test_google_video_api_shot_extractor(caplog):
         assert result['shot_id'][1] == 1
 
 
+@pytest.mark.long_test
 @pytest.mark.requires_payment
 @pytest.mark.skipif("'GOOGLE_APPLICATION_CREDENTIALS' not in os.environ")
 def test_google_video_api_explicit_extractor(caplog):

--- a/pliers/tests/extractors/api/test_google_extractors.py
+++ b/pliers/tests/extractors/api/test_google_extractors.py
@@ -187,7 +187,7 @@ def test_google_vision_api_extractor_large():
     config.set_option('allow_large_jobs', True)
     results = merge_results(ext.transform(images))
     assert 'GoogleVisionAPILabelExtractor#apple' in results.columns
-    assert results.shape == (2, 36)
+    assert results.shape == (2, 32)
 
     config.set_option('allow_large_jobs', default)
     config.set_option('large_job', default_large)

--- a/pliers/tests/extractors/test_image_extractors.py
+++ b/pliers/tests/extractors/test_image_extractors.py
@@ -69,6 +69,7 @@ def test_tensor_flow_inception_v3_extractor():
 
 
 def test_face_recognition_landmarks_extractor():
+    pytest.importorskip('face_recognition')
     ext = FaceRecognitionFaceLandmarksExtractor()
     imgs = [join(IMAGE_DIR, f) for f in ['apple.jpg', 'thai_people.jpg',
                                          'obama.jpg']]
@@ -84,6 +85,7 @@ def test_face_recognition_landmarks_extractor():
 
 
 def test_face_recognition_encodings_extractor():
+    pytest.importorskip('face_recognition')
     ext = FaceRecognitionFaceEncodingsExtractor()
     imgs = [join(IMAGE_DIR, f) for f in ['apple.jpg', 'thai_people.jpg',
                                          'obama.jpg']]
@@ -99,6 +101,7 @@ def test_face_recognition_encodings_extractor():
 
 
 def test_face_recognition_locations_extractor():
+    pytest.importorskip('face_recognition')
     ext = FaceRecognitionFaceLocationsExtractor()
     imgs = [join(IMAGE_DIR, f) for f in ['apple.jpg', 'thai_people.jpg',
                                          'obama.jpg']]

--- a/pliers/tests/filters/test_video_filters.py
+++ b/pliers/tests/filters/test_video_filters.py
@@ -21,6 +21,7 @@ def test_frame_sampling_video_filter():
     conv = FrameSamplingFilter(every=3)
     derived = conv.transform(video)
     assert derived.n_frames == math.ceil(video.n_frames / 3.0)
+    assert derived.duration == video.duration
     first = next(f for f in derived)
     assert type(first) == VideoFrameStim
     assert first.name == 'frame[0]'
@@ -28,6 +29,8 @@ def test_frame_sampling_video_filter():
     assert first.duration == 3 * (1 / 30.0)
     second = [f for f in derived][1]
     assert second.onset == 4.3
+    with pytest.raises(TypeError):
+        assert derived.get_frame(onset=1.0)
 
     # Should refilter from original frames
     conv = FrameSamplingFilter(hertz=15)

--- a/pliers/tests/filters/test_video_filters.py
+++ b/pliers/tests/filters/test_video_filters.py
@@ -30,17 +30,47 @@ def test_frame_sampling_video_filter():
     second = [f for f in derived][1]
     assert second.onset == 4.3
     with pytest.raises(TypeError):
-        assert derived.get_frame(onset=1.0)
+        derived.get_frame(onset=1.0)
 
-    # Should refilter from original frames
-    conv = FrameSamplingFilter(hertz=15)
-    derived = conv.transform(derived)
-    assert derived.n_frames == math.ceil(video.n_frames / 6.0)
-    first = next(f for f in derived)
-    assert type(first) == VideoFrameStim
-    assert first.duration == 3 * (1 / 15.0)
-    second = [f for f in derived][1]
-    assert second.onset == 4.4
+    # Commented out because no longer allowing sampling filter chaining
+    # conv = FrameSamplingFilter(hertz=15)
+    # derived = conv.transform(derived)
+    # assert derived.n_frames == math.ceil(video.n_frames / 6.0)
+    # first = next(f for f in derived)
+    # assert type(first) == VideoFrameStim
+    # assert first.duration == 3 * (1 / 15.0)
+    # second = [f for f in derived][1]
+    # assert second.onset == 4.4
+
+    with pytest.raises(TypeError):
+        conv.transform(derived)
+
+
+def test_frame_sampling_video_filter2():
+    filename = join(VIDEO_DIR, 'obama_speech.mp4')
+    video = VideoStim(filename, onset=4.2)
+    assert video.fps == 12
+    assert video.n_frames == 105
+
+    # Test frame indices
+    conv = FrameSamplingFilter(every=3)
+    derived = conv.transform(video)
+    assert derived.n_frames == 35
+    assert derived.frame_index[4] == 12
+    conv = FrameSamplingFilter(hertz=3)
+    derived = conv.transform(video)
+    assert derived.n_frames == 27
+    assert derived.frame_index[3] == 12
+    conv = FrameSamplingFilter(hertz=24)
+    derived = conv.transform(video)
+    assert derived.n_frames == 210
+    assert derived.frame_index[4] == 2
+    video.fps = 11.8
+    conv = FrameSamplingFilter(hertz=1)
+    derived = conv.transform(video)
+    assert derived.n_frames == 9
+    assert derived.frame_index[4] == 47
+    assert derived.frame_index[5] == 59
 
 
 def test_frame_sampling_cv2():

--- a/pliers/tests/test_graph.py
+++ b/pliers/tests/test_graph.py
@@ -381,7 +381,7 @@ def test_adding_nodes():
     txt = TextStim(text='the.best.text.')
     results = graph.run(txt, merge=False)
     assert len(results) == 1
-    assert results[0].to_df()['text_length'][0] == 13
+    assert results[0].to_df()['text_length'][0] == 11
 
     with pytest.raises(ValueError):
         graph.add_nodes(['LengthExtractor'], mode='invalid')

--- a/pliers/tests/test_stims.py
+++ b/pliers/tests/test_stims.py
@@ -87,8 +87,13 @@ def test_video_stim():
     f2 = video.get_frame(index=100)
     assert isinstance(f2, VideoFrameStim)
     assert isinstance(f2.onset, float)
-    assert f2.onset > 4.2
+    assert f2.onset > 7.5
     f2.data.shape == (320, 560, 3)
+    f2_copy = video.get_frame(onset=3.33334)
+    assert isinstance(f2, VideoFrameStim)
+    assert isinstance(f2.onset, float)
+    assert f2.onset > 7.5
+    assert np.array_equal(f2.data, f2_copy.data)
 
     # Try another video
     filename = join(get_test_data_path(), 'video', 'obama_speech.mp4')

--- a/pliers/tests/test_stims.py
+++ b/pliers/tests/test_stims.py
@@ -148,6 +148,7 @@ def test_complex_text_stim():
     stim = ComplexTextStim(join(text_dir, 'complex_stim_no_header.txt'),
                            columns='ot', default_duration=0.2, onset=4.2)
     assert stim.elements[2].onset == 38.2
+    assert stim.elements[1].onset == 24.2
     stim = ComplexTextStim(join(text_dir, 'complex_stim_with_header.txt'))
     assert len(stim.elements) == 4
     assert stim.elements[2].duration == 0.1

--- a/pliers/tests/test_stims.py
+++ b/pliers/tests/test_stims.py
@@ -12,10 +12,8 @@ from pliers.extractors.base import Extractor, ExtractorResult
 from pliers.support.download import download_nltk_data
 import numpy as np
 from os.path import join, exists
-import os
 import pandas as pd
 import pytest
-import tempfile
 
 
 class DummyExtractor(Extractor):
@@ -58,12 +56,14 @@ def test_image_stim(dummy_iter_extractor):
     stim = ImageStim(filename)
     assert stim.data.shape == (288, 420, 3)
 
+
 def test_complex_text_hash():
     stims = [ComplexTextStim(text='yeah'), ComplexTextStim(text='buddy')]
     ext = ComplexTextExtractor()
     res = ext.transform(stims)
 
     assert res[0]._data != res[1]._data
+
 
 def test_video_stim():
     ''' Test VideoStim functionality. '''
@@ -102,6 +102,15 @@ def test_video_stim():
     assert isinstance(f3.onset, float)
     assert f3.duration > 0.0
     assert f3.data.shape == (240, 320, 3)
+
+
+def test_video_frame_stim():
+    filename = join(get_test_data_path(), 'video', 'small.mp4')
+    video = VideoStim(filename, onset=4.2)
+    frame = VideoFrameStim(video, 42)
+    assert frame.onset == (5.6)
+    assert np.array_equal(frame.data, video.get_frame(index=42).data)
+    assert frame.name == 'frame[42]'
 
 
 def test_audio_stim():

--- a/pliers/tests/test_stims.py
+++ b/pliers/tests/test_stims.py
@@ -14,6 +14,8 @@ import numpy as np
 from os.path import join, exists
 import pandas as pd
 import pytest
+import tempfile
+import os
 
 
 class DummyExtractor(Extractor):
@@ -150,6 +152,9 @@ def test_complex_text_stim():
     assert len(stim.elements) == 4
     assert stim.elements[2].duration == 0.1
 
+    assert stim._to_sec((1.0, 42, 3, 0)) == 6123
+    assert stim._to_tup(6123) == (1.0, 42, 3, 0)
+
 
 def test_complex_stim_from_text():
     textfile = join(get_test_data_path(), 'text', 'scandal.txt')
@@ -260,20 +265,20 @@ def test_get_filename():
     assert not exists(filename)
 
 
-# def test_save():
-#     text_dir = join(get_test_data_path(), 'text')
-#     complextext_stim = ComplexTextStim(join(text_dir, 'complex_stim_no_header.txt'),
-#                                        columns='ot', default_duration=0.2)
-#     text_stim = TextStim(text='hello')
-#     video_stim = VideoStim(join(get_test_data_path(), 'video', 'small.mp4'))
-#     audio_stim = AudioStim(join(get_test_data_path(), 'audio', 'crowd.mp3'))
-#     image_stim = ImageStim(join(get_test_data_path(), 'image', 'apple.jpg'))
-#     stims = [complextext_stim, text_stim, video_stim, audio_stim, image_stim]
-#     for s in stims:
-#         path = tempfile.mktemp() + s._default_file_extension
-#         s.save(path)
-#         assert exists(path)
-#         os.remove(path)
+def test_save():
+    cts_file = join(get_test_data_path(), 'text', 'complex_stim_no_header.txt')
+    complextext_stim = ComplexTextStim(cts_file, columns='ot',
+                                       default_duration=0.2)
+    text_stim = TextStim(text='hello')
+    audio_stim = AudioStim(join(get_test_data_path(), 'audio', 'crowd.mp3'))
+    image_stim = ImageStim(join(get_test_data_path(), 'image', 'apple.jpg'))
+    # Video gives travis problems
+    stims = [complextext_stim, text_stim, audio_stim, image_stim]
+    for s in stims:
+        path = tempfile.mktemp() + s._default_file_extension
+        s.save(path)
+        assert exists(path)
+        os.remove(path)
 
 
 @pytest.mark.skipif("'TWITTER_ACCESS_TOKEN_KEY' not in os.environ")

--- a/pliers/transformers/api/google.py
+++ b/pliers/transformers/api/google.py
@@ -6,8 +6,8 @@ from pliers.utils import attempt_to_import, verify_dependencies
 
 
 googleapiclient = attempt_to_import('googleapiclient', fromlist=['discovery'])
-oauth_client = attempt_to_import('oauth2client.client', 'oauth_client',
-                                 ['GoogleCredentials'])
+google_auth = attempt_to_import('google.oauth2', 'google_auth',
+                                fromlist=['service_account'])
 
 
 DISCOVERY_URL = 'https://{api}.googleapis.com/$discovery/rest?version={apiVersion}'
@@ -31,7 +31,7 @@ class GoogleAPITransformer(APITransformer):
 
     def __init__(self, discovery_file=None, api_version='v1', max_results=100,
                  num_retries=3, rate_limit=None, **kwargs):
-        verify_dependencies(['googleapiclient', 'oauth_client'])
+        verify_dependencies(['googleapiclient', 'google_auth'])
         if discovery_file is None:
             if 'GOOGLE_APPLICATION_CREDENTIALS' not in os.environ:
                 raise ValueError("No Google application credentials found. "
@@ -43,8 +43,8 @@ class GoogleAPITransformer(APITransformer):
 
         self.discovery_file = discovery_file
         try:
-            self.credentials = oauth_client.GoogleCredentials.from_stream(
-                discovery_file)
+            self.credentials = google_auth.service_account.Credentials\
+                .from_service_account_file(discovery_file)
             self.service = googleapiclient.discovery.build(
                 self.api_name, api_version, credentials=self.credentials,
                 discoveryServiceUrl=DISCOVERY_URL)


### PR DESCRIPTION
A couple patches to the mechanics of `VideoStim` and `VideoFrameCollectionStim`.
-Changed the `get_frame` method to only accept an `onset` argument on `VideoStim`s, since this becomes ambiguous for `VideoFrameCollectionStim`s anyways
-Updates to make the sampling more accurate (rounded at the appropriate moment) in the `FrameSamplingFilter`. Made it possible to perform upsampling, but took away the ability to sample on an already-sampled `VideoFrameCollectionStim`

Resolves #294
Resolves #298

Cherry picked some commits from #299.
-Resolves #290. Removes punctuation that count as tokens
-Small update to the `speech_contexts` argument for the `GoogleSpeechAPIConverter`
-Small fix for audio sampling rate if initialized from an existing clip
-Added functionality to `ComplexTextStim` to enable output to .srt files