### PR TITLE
Removed old code in AudioStim

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,8 @@ before_install:
 install:
 - sudo apt-get install libboost-python-dev
 - pip install --upgrade --ignore-installed setuptools
-- pip install python-magic coveralls pytest-cov pysrt xlrd pytesseract
+- pip install python-magic moviepy coveralls pytest-cov pysrt xlrd pytesseract
 - pip install clarifai==2.1.0
-- pip install moviepy==0.2.2.13
 - pip install SpeechRecognition IndicoIo pygraphviz sklearn python-twitter gensim
   google-compute-engine librosa face_recognition google-api-python-client
 before_script:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 python-magic
 numpy>=1.8.1
 nltk>=3.0.0
-moviepy>=0.2.2.13
+moviepy>=0.2.3.5
 pandas>=0.20.0
 pillow
 requests


### PR DESCRIPTION
In light of moviepy being released with our patch (https://github.com/Zulko/moviepy/pull/665), we can go ahead and remove this bit of code to hack AudioStim sampling rate.

Requires users to install the newest version of moviepy.

Librosa on 2.7 still failing, not sure what's taking the new release so long.