### PR TITLE
Changed location of words list assignment for GoogleSpeechAPIConverter

### DIFF
--- a/pliers/converters/api/google.py
+++ b/pliers/converters/api/google.py
@@ -90,10 +90,10 @@ class GoogleSpeechAPIConverter(GoogleAPITransformer, AudioToTextConverter):
             raise Exception(response['error']['message'])
 
         offset = 0.0 if stim.onset is None else stim.onset
+	words = []
         if 'results' in response:
             for result in response['results']:
                 transcription = result['alternatives'][0]
-                words = []
                 for w in transcription['words']:
                     onset = float(w['startTime'][:-1])
                     duration = float(w['endTime'][:-1]) - onset

--- a/pliers/converters/api/google.py
+++ b/pliers/converters/api/google.py
@@ -90,7 +90,7 @@ class GoogleSpeechAPIConverter(GoogleAPITransformer, AudioToTextConverter):
             raise Exception(response['error']['message'])
 
         offset = 0.0 if stim.onset is None else stim.onset
-	words = []
+        words = []
         if 'results' in response:
             for result in response['results']:
                 transcription = result['alternatives'][0]


### PR DESCRIPTION
In using the GoogleSpeechAPIConverter within pliers I noticed a mistake in the location where the list containing all the transcribed words is assigned. The list is re-assigned with every new response from the API and so whatever was in all of the previous responses would get overwritten and only the last speech block will be returned as the final output.

I just quickly moved it outside the for loop so if it's transcribing a clip with multiple audio blocks, everything would get returned.

