### PR TITLE
Rev.ai speech-to-text API converter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ TODO.txt
 env.list
 docs/_build/
 docs/generated/
+.pytest_cache/

--- a/optional-dependencies.txt
+++ b/optional-dependencies.txt
@@ -20,3 +20,4 @@ spacy
 SpeechRecognition>=3.6.0
 tensorflow>=1.0.0
 xlrd
+rev_ai

--- a/pliers/converters/__init__.py
+++ b/pliers/converters/__init__.py
@@ -6,7 +6,8 @@ from .api import (WitTranscriptionConverter,
                   IBMSpeechAPIConverter,
                   GoogleSpeechAPIConverter,
                   GoogleVisionAPITextConverter,
-                  MicrosoftAPITextConverter)
+                  MicrosoftAPITextConverter,
+                  RevAISpeechAPIConverter)
 from .base import Converter, get_converter
 from .image import TesseractConverter
 from .iterators import (VideoFrameIterator, VideoFrameCollectionIterator,
@@ -27,6 +28,7 @@ __all__ = [
     'VideoToTextConverter',
     'VideoToComplexTextConverter',
     'VideoToAudioConverter',
+    'RevAISpeechAPIConverter',
     'Converter',
     'get_converter'
 ]

--- a/pliers/converters/api/__init__.py
+++ b/pliers/converters/api/__init__.py
@@ -2,11 +2,13 @@ from .wit import WitTranscriptionConverter
 from .ibm import IBMSpeechAPIConverter
 from .google import GoogleVisionAPITextConverter, GoogleSpeechAPIConverter
 from .microsoft import MicrosoftAPITextConverter
+from .revai import RevAISpeechAPIConverter
 
 __all__ = [
     'WitTranscriptionConverter',
     'IBMSpeechAPIConverter',
     'GoogleSpeechAPIConverter',
     'GoogleVisionAPITextConverter',
-    'MicrosoftAPITextConverter'
+    'MicrosoftAPITextConverter',
+    'RevAISpeechAPIConverter'
 ]

--- a/pliers/converters/api/google.py
+++ b/pliers/converters/api/google.py
@@ -89,7 +89,6 @@ class GoogleSpeechAPIConverter(GoogleAPITransformer, AudioToTextConverter):
         if 'error' in response:
             raise Exception(response['error']['message'])
 
-        offset = 0.0 if stim.onset is None else stim.onset
         words = []
         if 'results' in response:
             for result in response['results']:
@@ -98,7 +97,7 @@ class GoogleSpeechAPIConverter(GoogleAPITransformer, AudioToTextConverter):
                     onset = float(w['startTime'][:-1])
                     duration = float(w['endTime'][:-1]) - onset
                     words.append(TextStim(text=w['word'],
-                                          onset=offset + onset,
+                                          onset=onset,
                                           duration=duration))
 
         return ComplexTextStim(elements=words)

--- a/pliers/converters/api/ibm.py
+++ b/pliers/converters/api/ibm.py
@@ -77,7 +77,6 @@ class IBMSpeechAPIConverter(APITransformer, AudioToTextConverter):
 
     def _convert(self, audio):
         verify_dependencies(['sr'])
-        offset = 0.0 if audio.onset is None else audio.onset
 
         with audio.get_filename() as filename:
             with sr.AudioFile(filename) as source:
@@ -100,7 +99,7 @@ class IBMSpeechAPIConverter(APITransformer, AudioToTextConverter):
                         start = entry[1]
                         end = entry[2]
                         elements.append(TextStim(text=text,
-                                                 onset=offset+start,
+                                                 onset=start,
                                                  duration=end-start,
                                                  order=order))
                         order += 1
@@ -109,7 +108,7 @@ class IBMSpeechAPIConverter(APITransformer, AudioToTextConverter):
                     start = timestamps[0][1]
                     end = timestamps[-1][2]
                     elements.append(TextStim(text=text,
-                                             onset=offset+start,
+                                             onset=start,
                                              duration=end-start,
                                              order=order))
                     order += 1

--- a/pliers/converters/api/ibm.py
+++ b/pliers/converters/api/ibm.py
@@ -69,11 +69,8 @@ class IBMSpeechAPIConverter(APITransformer, AudioToTextConverter):
             self._send_request(request)
             return True
         except Exception as e:
-            if 'Not Authorized' in str(e):
-                logging.warn(str(e))
-                return False
-            else:
-                raise e
+            logging.warn(str(e))
+            return False
 
     def _convert(self, audio):
         verify_dependencies(['sr'])

--- a/pliers/converters/api/ibm.py
+++ b/pliers/converters/api/ibm.py
@@ -34,7 +34,7 @@ class IBMSpeechAPIConverter(APITransformer, AudioToTextConverter):
         rate_limit (int): The minimum number of seconds required between
             transform calls on this Transformer.
         model (str): The model to use for speech recognition (e.g., 'en-US',
-            'zh-CN', etc.). Don't include the "_BroadbandModel" suffix. 
+            'zh-CN', etc.). Don't include the "_BroadbandModel" suffix.
     '''
 
     _env_keys = ('IBM_USERNAME', 'IBM_PASSWORD')

--- a/pliers/converters/api/revai.py
+++ b/pliers/converters/api/revai.py
@@ -1,0 +1,113 @@
+''' Rev.ai API-based Converter classes '''
+
+import logging
+import os
+import time
+
+from pliers.stimuli.text import TextStim, ComplexTextStim
+from pliers.utils import attempt_to_import, verify_dependencies
+from pliers.converters.audio import AudioToTextConverter
+from pliers.transformers.api import APITransformer
+
+rev_ai = attempt_to_import('rev_ai')
+rev_ai_client = attempt_to_import('rev_ai.apiclient',
+                                  'rev_ai_client',
+                                  ['RevAiAPIClient'])
+
+
+class RevAISpeechAPIConverter(APITransformer, AudioToTextConverter):
+
+    ''' Uses the Rev AI speech-to-text API to transcribe an audio file.
+
+    Args:
+        access_token (str): API credential access token. Must be passed
+            explicitly or stored in the environment variable specified
+            in the _env_keys field.
+        timeout (int): Number of seconds to wait for audio transcription
+            to finish. Defaults to 90 seconds.
+        request_rate (int): Number of seconds to wait between polling the
+            API for completion.
+    '''
+
+    _env_keys = ('REVAI_ACCESS_TOKEN',)
+    _log_attributes = ('access_token', 'timeout', 'request_rate')
+    VERSION = '1.0'
+
+    def __init__(self, access_token=None, timeout=1000, request_rate=5):
+        verify_dependencies(['rev_ai_client'])
+        if access_token is None:
+            try:
+                access_token = os.environ['REVAI_ACCESS_TOKEN']
+            except KeyError:
+                raise ValueError("A valid API key must be passed when a "
+                                 "RevAISpeechAPIConverter is initialized.")
+        self.access_token = access_token
+        self.timeout = timeout
+        self.request_rate = request_rate
+        self.client = rev_ai_client.RevAiAPIClient(access_token)
+        super(RevAISpeechAPIConverter, self).__init__()
+
+    @property
+    def api_keys(self):
+        return [self.access_token]
+
+    def check_valid_keys(self):
+        try:
+            account = self.client.get_account()
+            if account.balance_seconds > 0:
+                return True
+            else:
+                logging.warn("Insufficient balance for Rev.ai speech "
+                             "converter: {}".format(account.balance_seconds))
+                return False
+        except Exception as e:
+            if 'Unauthorized' in str(e):
+                logging.warn(str(e))
+                return False
+            else:
+                raise e
+
+    def _convert(self, audio):
+        verify_dependencies(['rev_ai'])
+        offset = 0.0 if audio.onset is None else audio.onset
+
+        msg = "Beginning video extraction with a timeout of %fs. Even for "\
+              "small audios, full transcription may take awhile." % self.timeout
+        logging.warning(msg)
+
+        if audio.url:
+            job = self.client.submit_job_url(audio.url)
+        else:
+            with audio.get_filename() as filename:
+                job = self.client.submit_job_local_file(filename)
+
+        operation_start = time.time()
+        response = self.client.get_job_details(job.id)
+        while (response.status == rev_ai.JobStatus.IN_PROGRESS) and \
+              (time.time() - operation_start) < self.timeout:
+            response = self.client.get_job_details(job.id)
+            time.sleep(self.request_rate)
+
+        if (time.time() - operation_start) >= self.timeout:
+            msg = "Conversion reached the timeout limit of %fs." % self.timeout
+            logging.warning(msg)
+
+        if response.status == rev_ai.JobStatus.FAILED:
+            raise Exception('API failed: %s' % response.failure_detail)
+
+        result = self.client.get_transcript_object(job.id)
+
+        elements = []
+        order = 0
+        for m in result.monologues:
+            for e in m.elements:
+                if e.type_ == 'text':
+                    start = e.timestamp
+                    end = e.end_timestamp
+                    elements.append(TextStim(text=e.value,
+                                             onset=offset+start,
+                                             duration=end-start,
+                                             order=order))
+                    order += 1
+
+        return ComplexTextStim(elements=elements, onset=audio.onset)

--- a/pliers/converters/api/revai.py
+++ b/pliers/converters/api/revai.py
@@ -61,11 +61,8 @@ class RevAISpeechAPIConverter(APITransformer, AudioToTextConverter):
                              "converter: {}".format(account.balance_seconds))
                 return False
         except Exception as e:
-            if 'Unauthorized' in str(e):
-                logging.warn(str(e))
-                return False
-            else:
-                raise e
+            logging.warn(str(e))
+            return False
 
     def _convert(self, audio):
         verify_dependencies(['rev_ai'])

--- a/pliers/converters/api/revai.py
+++ b/pliers/converters/api/revai.py
@@ -69,9 +69,7 @@ class RevAISpeechAPIConverter(APITransformer, AudioToTextConverter):
 
     def _convert(self, audio):
         verify_dependencies(['rev_ai'])
-        offset = 0.0 if audio.onset is None else audio.onset
-
-        msg = "Beginning video extraction with a timeout of %fs. Even for "\
+        msg = "Beginning audio transcription with a timeout of %fs. Even for "\
               "small audios, full transcription may take awhile." % self.timeout
         logging.warning(msg)
 
@@ -105,7 +103,7 @@ class RevAISpeechAPIConverter(APITransformer, AudioToTextConverter):
                     start = e.timestamp
                     end = e.end_timestamp
                     elements.append(TextStim(text=e.value,
-                                             onset=offset+start,
+                                             onset=start,
                                              duration=end-start,
                                              order=order))
                     order += 1

--- a/pliers/extractors/text.py
+++ b/pliers/extractors/text.py
@@ -2,7 +2,7 @@
 Extractors that operate primarily or exclusively on Text stimuli.
 '''
 import sys
-#sys.path.insert(0,'C:\\Users\\jayee\\Documents\\Tal-Pliers\\pliers' )
+
 from pliers.stimuli.text import TextStim, ComplexTextStim
 from pliers.extractors.base import Extractor, ExtractorResult
 from pliers.support.exceptions import PliersError
@@ -20,13 +20,12 @@ import logging
 from six import string_types
 
 
-
-
 keyedvectors = attempt_to_import('gensim.models.keyedvectors', 'keyedvectors',
                                  ['KeyedVectors'])
 sklearn_text = attempt_to_import('sklearn.feature_extraction.text', 'sklearn_text',
                                  ['VectorizerMixin', 'CountVectorizer'])
 spacy = attempt_to_import('spacy')
+
 
 class TextExtractor(Extractor):
 

--- a/pliers/tests/converters/api/test_revai_converters.py
+++ b/pliers/tests/converters/api/test_revai_converters.py
@@ -1,0 +1,28 @@
+from os.path import join
+from ...utils import get_test_data_path
+from pliers.converters import RevAISpeechAPIConverter
+from pliers.stimuli import AudioStim, ComplexTextStim, TextStim
+import pytest
+
+AUDIO_DIR = join(get_test_data_path(), 'audio')
+
+
+@pytest.mark.requires_payment
+@pytest.mark.skipif("'REVAI_ACCESS_TOKEN' not in os.environ")
+def test_googleAPI_converter():
+    stim = AudioStim(join(AUDIO_DIR, 'obama_speech.wav'), onset=4.2)
+    conv = RevAISpeechAPIConverter()
+    assert conv.validate_keys()
+    out_stim = conv.transform(stim)
+    assert type(out_stim) == ComplexTextStim
+    text = [elem.text for elem in out_stim]
+    assert 'years' in text
+    assert 'together' in text
+
+    first_word = next(w for w in out_stim)
+    assert isinstance(first_word, TextStim)
+    assert first_word.duration > 0
+    assert first_word.onset > 4.2 and first_word.onset < 8.0
+
+    conv = RevAISpeechAPIConverter(access_token='badtoken')
+    assert not conv.validate_keys()

--- a/pliers/tests/extractors/test_audio_extractors.py
+++ b/pliers/tests/extractors/test_audio_extractors.py
@@ -217,6 +217,7 @@ def test_tempogram_extractor():
     assert df.shape == (1221, 304)
     assert np.isclose(df['tempo_1'][2], 0.74917)
 
+
 def test_rms_extractor():
     audio = AudioStim(join(AUDIO_DIR, 'barber.wav'))
     ext = RMSExtractor()
@@ -225,15 +226,16 @@ def test_rms_extractor():
     assert np.isclose(df['onset'][2], 0.092880)
     assert np.isclose(df['duration'][2], 0.04644)
     assert np.isclose(df['rms'][2], 0.229993)
-    
+
     assert np.isclose(df['onset'][4], 0.185760)
     assert np.isclose(df['duration'][4], 0.04644)
     assert np.isclose(df['rms'][4], 0.184349)
-    
+
     assert np.isclose(df['onset'][1219], 56.610249)
     assert np.isclose(df['duration'][1219], 0.04644)
-    assert np.isclose(df['rms'][1219], 0.001348, rtol = 1e-03)
-    
+    assert np.isclose(df['rms'][1219], 0.001348, rtol=1e-03)
+
+
 def test_spectral_flatness_extractor():
     audio = AudioStim(join(AUDIO_DIR, 'barber.wav'))
     ext = SpectralFlatnessExtractor()
@@ -242,15 +244,16 @@ def test_spectral_flatness_extractor():
     assert np.isclose(df['onset'][10], 0.464399)
     assert np.isclose(df['duration'][10], 0.04644)
     assert np.isclose(df['spectral_flatness'][10], 0.035414)
-    
+
     assert np.isclose(df['onset'][25], 1.160998)
     assert np.isclose(df['duration'][25], 0.04644)
     assert np.isclose(df['spectral_flatness'][25], 0.084409)
-    
+
     assert np.isclose(df['onset'][1215], 56.424490)
     assert np.isclose(df['duration'][1215], 0.04644)
     assert np.isclose(df['spectral_flatness'][1215], 0.0349364)
-    
+
+
 def test_onset_detect_extractor():
     audio = AudioStim(join(AUDIO_DIR, 'barber.wav'))
     ext = OnsetDetectExtractor()
@@ -259,15 +262,16 @@ def test_onset_detect_extractor():
     assert np.isclose(df['onset'][1], 0.046440)
     assert np.isclose(df['duration'][1], 0.04644)
     assert np.isclose(df['onset_detect'][1], 56)
-    
+
     assert np.isclose(df['onset'][5], 0.232200)
     assert np.isclose(df['duration'][5], 0.04644)
     assert np.isclose(df['onset_detect'][5], 85)
-    
+
     assert np.isclose(df['onset'][121], 5.619229)
     assert np.isclose(df['duration'][121], 0.04644)
     assert np.isclose(df['onset_detect'][121], 896)
-    
+
+
 def test_onset_multi_extractor():
     audio = AudioStim(join(AUDIO_DIR, 'barber.wav'))
     ext = OnsetStrengthMultiExtractor()
@@ -276,15 +280,16 @@ def test_onset_multi_extractor():
     assert np.isclose(df['onset'][10], 0.464399)
     assert np.isclose(df['duration'][10], 0.04644)
     assert np.isclose(df['onset_strength_multi'][10], 0.821330)
-    
+
     assert np.isclose(df['onset'][15], 0.696599)
     assert np.isclose(df['duration'][15], 0.04644)
     assert np.isclose(df['onset_strength_multi'][15], 0.430218)
-    
+
     assert np.isclose(df['onset'][1218], 56.563810)
     assert np.isclose(df['duration'][1218], 0.04644)
     assert np.isclose(df['onset_strength_multi'][1218], 0.058071)
-    
+
+
 def test_tempo_extractor():
     audio = AudioStim(join(AUDIO_DIR, 'barber.wav'))
     ext = TempoExtractor()
@@ -293,7 +298,8 @@ def test_tempo_extractor():
     assert np.isclose(df['onset'][0], 0.0)
     assert np.isclose(df['duration'][0], 0.04644)
     assert np.isclose(df['tempo'][0], 117.453835)
-    
+
+
 def test_beat_track_extractor():
     audio = AudioStim(join(AUDIO_DIR, 'barber.wav'))
     ext = BeatTrackExtractor()
@@ -302,15 +308,16 @@ def test_beat_track_extractor():
     assert np.isclose(df['onset'][2], 0.092880)
     assert np.isclose(df['duration'][2], 0.04644)
     assert np.isclose(df['beat_track'][2], 87)
-    
+
     assert np.isclose(df['onset'][29], 1.346757)
     assert np.isclose(df['duration'][29], 0.04644)
     assert np.isclose(df['beat_track'][29], 389)
-    
+
     assert np.isclose(df['onset'][101], 4.690431)
     assert np.isclose(df['duration'][101], 0.04644)
     assert np.isclose(df['beat_track'][101], 1195)
-    
+
+
 def test_harmonic_extractor():
     audio = AudioStim(join(AUDIO_DIR, 'barber.wav'))
     ext = HarmonicExtractor()
@@ -318,16 +325,17 @@ def test_harmonic_extractor():
     assert df.shape == (624786, 5)
     assert np.isclose(df['onset'][8], 0.371519)
     assert np.isclose(df['duration'][8], 0.04644)
-    assert np.isclose(df['harmonic'][8], -0.026663, rtol = 1e-4)
-    
+    assert np.isclose(df['harmonic'][8], -0.026663, rtol=1e-4)
+
     assert np.isclose(df['onset'][19], 0.882358)
     assert np.isclose(df['duration'][19], 0.04644)
-    assert np.isclose(df['harmonic'][19], 0.031422, rtol = 1e-4)
-    
+    assert np.isclose(df['harmonic'][19], 0.031422, rtol=1e-4)
+
     assert np.isclose(df['onset'][29], 1.346757)
     assert np.isclose(df['duration'][29], 0.04644)
-    assert np.isclose(df['harmonic'][29], -0.004497, rtol = 1e-4)
-    
+    assert np.isclose(df['harmonic'][29], -0.004497, rtol=1e-4)
+
+
 def test_percussion_extractor():
     audio = AudioStim(join(AUDIO_DIR, 'barber.wav'))
     ext = PercussiveExtractor()
@@ -335,12 +343,12 @@ def test_percussion_extractor():
     assert df.shape == (624786, 5)
     assert np.isclose(df['onset'][9], 0.417959)
     assert np.isclose(df['duration'][9], 0.04644)
-    assert np.isclose(df['percussive'][9], 0.028902, rtol = 1e-4)
-    
+    assert np.isclose(df['percussive'][9], 0.028902, rtol=1e-4)
+
     assert np.isclose(df['onset'][17], 0.789478)
     assert np.isclose(df['duration'][17], 0.04644)
-    assert np.isclose(df['percussive'][17], -0.031428, rtol = 1e-4)
-    
+    assert np.isclose(df['percussive'][17], -0.031428, rtol=1e-4)
+
     assert np.isclose(df['onset'][29], 1.346757)
     assert np.isclose(df['duration'][29], 0.04644)
-    assert np.isclose(df['percussive'][29], 0.004497, rtol = 1e-4)
+    assert np.isclose(df['percussive'][29], 0.004497, rtol=1e-4)

--- a/pliers/tests/extractors/test_text_extractors.py
+++ b/pliers/tests/extractors/test_text_extractors.py
@@ -159,15 +159,16 @@ def test_vader_sentiment_extractor():
     assert result2['sentiment_neu'][0] == 0.248
     assert result2['sentiment_compound'][0] == 0.8439
 
-    
+
 def test_spacy_token_extractor():
+    pytest.importorskip('spacy')
     stim = TextStim(text='This is a test.')
     ext = SpaCyExtractor(extractor_type='token')
     assert ext.model is not None
-    
+
     ext2 = SpaCyExtractor(model='en_core_web_sm')
     assert isinstance(ext2.model, spacy.lang.en.English)
-    
+
     result = ext.transform(stim).to_df()
     assert result['text'][0] == 'This'
     assert result['lemma_'][0].lower() == 'this'
@@ -181,7 +182,7 @@ def test_spacy_token_extractor():
     assert result['is_ascii'][0] == 'True'
     assert result['is_digit'][0] == 'False'
     assert result['sentiment'][0] == '0.0'
-    
+
     assert result['text'][1] == 'is'
     assert result['lemma_'][1].lower() == 'be'
     assert result['pos_'][1] == 'VERB'
@@ -194,7 +195,7 @@ def test_spacy_token_extractor():
     assert result['is_ascii'][1] == 'True'
     assert result['is_digit'][1] == 'False'
     assert result['sentiment'][1] == '0.0'
-    
+
     assert result['text'][2] == 'a'
     assert result['lemma_'][2].lower() == 'a'
     assert result['pos_'][2] == 'DET'
@@ -207,7 +208,7 @@ def test_spacy_token_extractor():
     assert result['is_ascii'][2] == 'True'
     assert result['is_digit'][2] == 'False'
     assert result['sentiment'][2] == '0.0'
-    
+
     assert result['text'][3] == 'test'
     assert result['lemma_'][3].lower() == 'test'
     assert result['pos_'][3] == 'NOUN'
@@ -219,21 +220,22 @@ def test_spacy_token_extractor():
     assert result['is_punct'][3] == 'False'
     assert result['is_ascii'][3] == 'True'
     assert result['is_digit'][3] == 'False'
-    assert result['sentiment'][3] == '0.0'    
+    assert result['sentiment'][3] == '0.0'
 
 
 def test_spacy_doc_extractor():
+    pytest.importorskip('spacy')
     stim2 = TextStim(text='This is a test. And we are testing again. This '
                      'should be quite interesting. Tests are totally fun.')
     ext = SpaCyExtractor(extractor_type='doc')
     assert ext.model is not None
-    
+
     result = ext.transform(stim2).to_df()
     assert result['text'][0]=='This is a test. '
     assert result['is_parsed'][0]
     assert result['is_tagged'][0]
     assert result['is_sentenced'][0]
-    
+
     assert result['text'][3]=='Tests are totally fun.'
     assert result['is_parsed'][3]
     assert result['is_tagged'][3]


### PR DESCRIPTION
Shameless self-promotion 😄

The Rev AI API should be more accurate and cheaper than the other APIs currently implemented in pliers (maybe only comparable with the Google "video" model for speech-to-text, which is more expensive). Already on our small obama_speech.wav test file, the transcript is essentially perfect. It should be particularly better for long-form audios such as podcasts, interviews, speeches, etc. One downside is the relatively slow turn-around time for short audios (in contrast to the relatively fast TAT for long audio).

Also in the PR:
-Miscellaneous linting updates
-Small bug fix for AudioToTextConverters where origin audio stim onset was being added twice

~Note: I added my trial credentials to travis, but these will expire after 300 free minutes~
Update: nevermind, realizing we cut "requires_payment" tests from travis

For more info: https://www.rev.ai/