### PR TITLE
Expanded/improved predefined dictionary list

### DIFF
--- a/pliers/datasets/dictionaries.json
+++ b/pliers/datasets/dictionaries.json
@@ -57,7 +57,7 @@
         "title": "SUBTLEX US English word frequency for 60,384 words that have a frequency higher than 1",
         "description_url": "https://www.ugent.be/pp/experimentele-psychologie/en/research/documents/subtlexus",
         "source": "Brysbaert, M., & New, B. (2009). Moving beyond Kučera and Francis: A critical evaluation of current word frequency norms and the introduction of a new and improved word frequency measure for American English. Behavior research methods, 41(4), 977-990.",
-        "url": "https://www.ugent.be/pp/experimentele-psychologie/en/research/documents/subtlexus/subtlexus1.zip",
+        "url": "https://www.ugent.be/pp/experimentele-psychologie/en/research/documents/subtlexus/subtlexus1.zip/at_download/file",
         "license": "",
         "format": "xls",
         "language": "english",

--- a/pliers/datasets/dictionaries.json
+++ b/pliers/datasets/dictionaries.json
@@ -47,7 +47,7 @@
         "source": "Brysbaert, M., Warriner, A.B., & Kuperman, V. (2014). Concreteness ratings for 40 thousand generally known English word lemmas. Behavior Research Methods, 46, 904-911.",
         "url": "http://crr.ugent.be/papers/Concreteness_ratings_Brysbaert_et_al_BRM.txt",
         "license": "http://creativecommons.org/licenses/by-nc-nd/3.0/deed.en_US",
-        "format": "tsv",
+        "format": "tsv",    
         "language": "english",
         "columns": ["Bigram", "Conc.M", "Conc.SD", "Unknown", "Total",
                     "Percent_known", "SUBTLEX", "Dom_Pos"]
@@ -90,5 +90,41 @@
         "format": "xls",
         "language": "english",
         "columns": ["VersionNum", "WordType", "Block", "Word_ID_unique", "RTclean_mean", "RTclean_sd", "Rtclean_n", "zRTclean_mean", "zRTclean_sd", "zRTclean_n", "ACC", "ACC_n", "Concrete_rating"]
+    },
+
+    "massiveauditorylexicaldecision": {
+        "title": "The Massive Auditory Lexical Decision (MALD) database",
+        "description_url": "http://aphl.artsrn.ualberta.ca/?page_id=827",
+        "source": "Tucker, B. V., Brenner, D., Danielson, D. K., Kelley, M. C., Nenadic, F., & Sims, M. (2019). The Massive Auditory Lexical Decision (MALD) database. Behavior Research Methods.",
+        "doi": "10.3758/s13428-018-1056-1",
+        "url": "https://era.library.ualberta.ca/items/6f793ba5-44a8-4ed9-95a0-3cd7052c10f1/download/e2421732-b28c-427e-afcf-d7668955a33e",
+        "license": "https://creativecommons.org/licenses/by-nc/4.0/",
+        "format": "tsv",
+        "language": "english",
+        "columns": ["WAV", "Pronunciation", "IsWord", "StressPattern", "NumSylls", "NumPhones", "Duration", "OrthUP", "PhonND", "OrthND", "POS", "AllPOS", "FreqSUBTLEX", "FreqCOCA", "FreqCOCAspok", "FreqGoogle", "PhonUP", "StressCat", "Dbet", "PhonLev", "NumMorphs", "OrthLev"],
+        "column_descriptions": [
+            "The name of the sound file.",
+            "Transcription of the item phones in the Arpabet transcription scheme.",
+            "Whether the item is a word or pseudo-word.",
+            "The stress pattern of the word.",
+            "The number of syllables in the item.",
+            "The number of phones in the item.",
+            "The duration of the item in milliseconds.",
+            "The letter index of the orthographic uniqueness point of the item.",
+            "The number of phonological neighbors (one phone edit away).",
+            "The number of orthographic neighbors (one glyph edit away).",
+            "The frequency-dominant part-of-speech of the orthographic form.",
+            "All parts-of-speech of the orthographic wordform.",
+            "The frequency of the orthographic word form (SUBTLEX-US corpus).",
+            "Word frequency in the COCA corpus.",
+            "Word frequency in the spoken language subset of the COCA corpus.",
+            "Word frequency in the Google Unigram corpus.",
+            "The phone index of the phonological uniqueness point of the item.",
+            "The stress category of word items.",
+            "",
+            "Mean phone-level Levenshtein distance from all entries in CMU-A.",
+            "The number of morphemes.",
+            "Mean orthographic Levenshtein distance from all entries in CMU-A."
+        ]
     }
 }

--- a/pliers/datasets/dictionaries.json
+++ b/pliers/datasets/dictionaries.json
@@ -55,13 +55,40 @@
 
     "subtlexusfrequency": {
         "title": "SUBTLEX US English word frequency for 60,384 words that have a frequency higher than 1",
-        "description_url": "http://www.ugent.be/pp/experimentele-psychologie/en/research/documents/subtlexus/overview.htm",
+        "description_url": "https://www.ugent.be/pp/experimentele-psychologie/en/research/documents/subtlexus",
         "source": "Brysbaert, M., & New, B. (2009). Moving beyond Kučera and Francis: A critical evaluation of current word frequency norms and the introduction of a new and improved word frequency measure for American English. Behavior research methods, 41(4), 977-990.",
-        "url": "https://www.ugent.be/pp/experimentele-psychologie/en/research/documents/subtlexus/subtlexus4.zip/at_download/file",
+        "url": "https://www.ugent.be/pp/experimentele-psychologie/en/research/documents/subtlexus/subtlexus1.zip",
         "license": "",
         "format": "xls",
         "language": "english",
         "columns": ["FREQcount", "CDcount", "FREQlow", "Cdlow", "SUBTLWF",
-                    "Lg10WF", "SUBTLCD", "Lg10CD"]
+                    "Lg10WF", "SUBTLCD", "Lg10CD", "Dom_PoS_SUBTLEX", "Freq_dom_PoS_SUBTLEX", "Percentage_dom_PoS", "All_PoS_SUBTLEX", "All_freqs_SUBTLEX", "Zipf-value"],
+        "column_descriptions": [
+          "Number of times the word appears in the corpus",
+          "The number of films in which the word appears",
+          "The number of times the word appears in the corpus starting with a lowercase letter",
+          "The number of films in which the word appears starting with a lowercase letter",
+          "The word frequency per million words",
+          "This value is based on log10(FREQcount+1)",
+          "Indicates in what percent of the films the word appears",
+          "This value is based on log10(CDcount+1)",
+          "The dominant (most frequent) part of speech of each entry",
+          "The frequency of the dominant part of speech",
+          "The relative frequency of the dominant part of speech",
+          "All parts of speech observed for the entry",
+          "The frequencies of each part of speech",
+          "Zipf frequency"
+        ]
+    },
+
+    "calgarysemanticdecision": {
+        "title": "The Calgary semantic decision project: concrete/abstract decision data for 10,000 English words",
+        "description_url": "https://psyc.ucalgary.ca/languageprocessing/node/22",
+        "source": "Pexman, P. M., Heard, A., Lloyd, E., & Yap, M. J. (2017). The Calgary semantic decision project: concrete/abstract decision data for 10,000 English words. Behavior Research Methods, 49(2), 407-417.",
+        "url": "https://psychology.ucalgary.ca/languageprocessing/sites/psyc.ucalgary.ca.languageprocessing/files/calgary_sdt_itemwise_data.xls",
+        "license": "",
+        "format": "xls",
+        "language": "english",
+        "columns": ["VersionNum", "WordType", "Block", "Word_ID_unique", "RTclean_mean", "RTclean_sd", "Rtclean_n", "zRTclean_mean", "zRTclean_sd", "zRTclean_n", "ACC", "ACC_n", "Concrete_rating"]
     }
 }

--- a/pliers/datasets/text.py
+++ b/pliers/datasets/text.py
@@ -45,7 +45,7 @@ def _download_dictionary(url, format, rename):
     if format == 'csv' or url.endswith('csv'):
         data = pd.read_csv(_file)
     elif format == 'tsv' or url.endswith('tsv'):
-        data = pd.read_table(_file, sep='\t')
+        data = pd.read_csv(_file, sep='\t')
     elif format.startswith('xls') or os.path.splitext(url)[1].startswith('xls'):
         data = pd.read_excel(_file)
 
@@ -55,7 +55,7 @@ def _download_dictionary(url, format, rename):
 
 
 def fetch_dictionary(name, url=None, format=None, index=0, rename=None,
-                     save=True):
+                     save=True, force_retrieve=False):
     ''' Retrieve a dictionary of text norms from the web or local storage.
 
     Args:
@@ -77,16 +77,20 @@ def fetch_dictionary(name, url=None, format=None, index=0, rename=None,
             locally-saved dictionary will retain the renamed columns.
         save (bool): Whether or not to save the dictionary locally the first
             time it is retrieved.
+        force_retrieve (bool): If True, remote dictionary will always be
+            downloaded, even if a local copy exists (and the local copy will
+            be overwritten).
+
     Returns: A pandas DataFrame indexed by strings (typically words).
 
     '''
     file_path = os.path.join(_get_dictionary_path(), name + '.csv')
-    if os.path.exists(file_path):
+    if not force_retrieve and os.path.exists(file_path):
         df = pd.read_csv(file_path)
         index = datasets[name].get('index', df.columns[index])
         return df.set_index(index)
 
-    elif name in datasets:
+    if name in datasets:
         url = datasets[name]['url']
         format = datasets[name].get('format', format)
         index = datasets[name].get('index', index)

--- a/pliers/extractors/text.py
+++ b/pliers/extractors/text.py
@@ -144,7 +144,12 @@ class PredefinedDictionaryExtractor(DictionaryExtractor):
             d.columns = ['%s_%s' % (k, c) for c in d.columns]
             dicts.append(d)
 
-        dictionary = pd.concat(dicts, axis=1, join='outer')
+        # Make sure none of the dictionaries have duplicate indices
+        drop_dups = lambda d: d[~d.index.duplicated(keep='first')]
+        dicts = [d if d.index.is_unique else drop_dups(d) for d in dicts]
+
+        dictionary = pd.concat(dicts, axis=1, join='outer', sort=False)
+
         super(PredefinedDictionaryExtractor, self).__init__(
             dictionary, missing=missing)
 

--- a/pliers/extractors/text.py
+++ b/pliers/extractors/text.py
@@ -115,12 +115,16 @@ class PredefinedDictionaryExtractor(DictionaryExtractor):
             a dictionary (defaults to numpy's NaN).
         case_sensitive (bool): If True, entries in the dictionary are treated
             as case-sensitive (e.g., 'John' and 'john' are different words).
+        force_retrieve (bool): If True, the source dictionary will always be
+            retrieved/download, even if it exists locally. If False, a cached
+            local version will be used if it exists.
     '''
 
     _log_attributes = ('variables', 'missing', 'case_sensitive')
     VERSION = '1.0'
 
-    def __init__(self, variables, missing=np.nan, case_sensitive=True):
+    def __init__(self, variables, missing=np.nan, case_sensitive=True,
+                 force_retrieve=False):
 
         self.case_sensitive = case_sensitive
 
@@ -136,7 +140,7 @@ class PredefinedDictionaryExtractor(DictionaryExtractor):
 
         dicts = []
         for k, v in variables.items():
-            d = fetch_dictionary(k)
+            d = fetch_dictionary(k, force_retrieve=force_retrieve)
             if not case_sensitive:
                 d.index = d.index.str.lower()
             if v:

--- a/pliers/tests/extractors/test_text_extractors.py
+++ b/pliers/tests/extractors/test_text_extractors.py
@@ -76,6 +76,25 @@ def test_predefined_dictionary_extractor():
     assert np.isclose(result['aoa_Freq_pm'][0], 10.313725, 1e-5)
 
 
+def test_predefined_dictionary_retrieval():
+    variables = [
+        'affect/D.Mean.H',
+        'concreteness/SUBTLEX',
+        'subtlexusfrequency/Zipf-value',
+        'calgarysemanticdecision/RTclean_mean',
+        'massiveauditorylexicaldecision/PhonLev'
+    ]
+    stim = TextStim(text='perhaps')
+    td = PredefinedDictionaryExtractor(variables)
+    result = td.transform(stim).to_df().iloc[0]
+    assert np.isnan(result['affect_D.Mean.H'])
+    assert result['concreteness_SUBTLEX'] == 6939
+    assert result['calgarysemanticdecision_RTclean_mean'] == 954.48
+    assert np.isclose(result['subtlexusfrequency_Zipf-value'], 5.1331936)
+    assert np.isclose(result['massiveauditorylexicaldecision_PhonLev'],
+                      6.65101626)
+
+
 def test_part_of_speech_extractor():
     import nltk
     nltk.download('tagsets')

--- a/pliers/tests/test_datasets.py
+++ b/pliers/tests/test_datasets.py
@@ -9,7 +9,4 @@ def test_dicts_exist_at_url_and_initialize():
     datasets = _load_datasets()
     for name, dataset in datasets.items():
         r = requests.head(dataset['url'])
-        assert r.status_code == requests.codes.ok
-        # read_excel() is doing some weird things, so disable for the moment
-        # data = fetch_dictionary(name, save=False)
-        # assert isinstance(data.shape, tuple)
+        assert r.status_code in (200, 301)


### PR DESCRIPTION
Updates and expands the predefined dictionary list:

* SUBTLEXus now points to a newer version that includes extra columns
* Adds Calgary Semantic Decision Project norms (Pexman et al., 2017)
* Adds Massive Auditory Lexical Decision norms (Tucker et al., 2019)
* Adds `column_descriptions` field to some dictionaries, though this isn't used anywhere internally right now
* Fixes handling of dictionaries with duplicate index entries
* Adds `force_retrieve` flag to `PredefinedDictionaryExtractor` that forces re-download of source dictionaries