### PR TITLE
Add: ImageResizeFilter

### DIFF
--- a/pliers/filters/__init__.py
+++ b/pliers/filters/__init__.py
@@ -6,6 +6,7 @@ some changes to its data).
 from .audio import AudioTrimmingFilter
 from .base import TemporalTrimmingFilter
 from .image import (ImageCroppingFilter,
+                    ImageResizingFilter,
                     PillowImageFilter)
 from .text import (WordStemmingFilter,
                    TokenizingFilter,
@@ -20,6 +21,7 @@ __all__ = [
     'AudioTrimmingFilter',
     'TemporalTrimmingFilter',
     'ImageCroppingFilter',
+    'ImageResizingFilter',
     'PillowImageFilter',
     'WordStemmingFilter',
     'TokenizingFilter',

--- a/pliers/filters/image.py
+++ b/pliers/filters/image.py
@@ -53,20 +53,31 @@ class ImageResizingFilter(ImageFilter):
             maintaining aspect ratio, and pad the rest with zero values.
             Otherwise, potentially distort the image during resizing to fit the
             new size.
-        resample (int): resampling method. 0 for nearest neighbor, 1 for
-            Lanczos, 2 for bilinear, 3 for bicubic (default), 4 for box, and 5 for
-            hamming. See https://pillow.readthedocs.io/en/5.1.x/handbook/concepts.html#concept-filters
+        resample str: resampling method. One of 'nearest', 'bilinear',
+            'bicubic', 'lanczos', 'box', and 'hamming'. See
+            https://pillow.readthedocs.io/en/5.1.x/handbook/concepts.html#concept-filters
             for more information.
     '''
 
     _log_attributes = ('size', 'maintain_aspect_ratio', 'resample')
     VERSION = '1.0'
 
-    def __init__(self, size, maintain_aspect_ratio=False,
-                 resample=Image.BICUBIC):
+    def __init__(self, size, maintain_aspect_ratio=False, resample='bicubic'):
         self.size = size
         self.maintain_aspect_ratio = maintain_aspect_ratio
-        self.resample = resample
+        resampling_mapping = {
+            'nearest': Image.NEAREST,
+            'bilinear': Image.BILINEAR,
+            'bicubic': Image.BICUBIC,
+            'lanczos': Image.LANCZOS,
+            'box': Image.BOX,
+            'hamming': Image.HAMMING,
+        }
+        if resample.lower() not in resampling_mapping.keys():
+            raise ValueError(
+                "Unknown resampling method '{}'. Allowed values are '{}'"
+                .format(resample, "', '".join(resampling_mapping.keys())))
+        self.resample = resampling_mapping[resample]
         super(ImageResizingFilter, self).__init__()
 
     def _filter(self, stim):

--- a/pliers/filters/image.py
+++ b/pliers/filters/image.py
@@ -43,6 +43,58 @@ class ImageCroppingFilter(ImageFilter):
                          data=new_img)
 
 
+class ImageResizingFilter(ImageFilter):
+
+    ''' Resizes an image, while optionally maintaining aspect ratio.
+
+    Args:
+        size (tuple of two ints): new size of the image.
+        maintain_aspect_ratio (boolean): if true, resize the image while
+            maintaining aspect ratio, and pad the rest with zero values.
+            Otherwise, potentially distort the image during resizing to fit the
+            new size.
+        resample (int): resampling method. 0 for nearest neighbor, 1 for
+            Lanczos, 2 for bilinear, 3 for bicubic (default), 4 for box, and 5 for
+            hamming. See https://pillow.readthedocs.io/en/5.1.x/handbook/concepts.html#concept-filters
+            for more information.
+    '''
+
+    _log_attributes = ('size', 'maintain_aspect_ratio', 'resample')
+    VERSION = '1.0'
+
+    def __init__(self, size, maintain_aspect_ratio=False,
+                 resample=Image.BICUBIC):
+        self.size = size
+        self.maintain_aspect_ratio = maintain_aspect_ratio
+        self.resample = resample
+        super(ImageResizingFilter, self).__init__()
+
+    def _filter(self, stim):
+        pillow_img = Image.fromarray(stim.data)
+
+        if not self.maintain_aspect_ratio:
+            new_img = np.array(
+                pillow_img.resize(self.size, resample=self.resample))
+        else:
+            # Resize the image to the requested size in one of the dimensions.
+            # We then create a black image of the requested size and paste the
+            # resized image into the middle of this new image. The effect is
+            # that there is a black border on the top and bottom or the left
+            # and right of the resized image.
+            orig_size = pillow_img.size
+            ratio = max(self.size) / max(orig_size)
+            inter_size = (np.array(orig_size) * ratio).astype(np.int32)
+            inter_img = pillow_img.resize(inter_size, resample=self.resample)
+            new_img = Image.new('RGB', self.size)
+            upper_left = (
+                (self.size[0] - inter_size[0]) // 2,
+                (self.size[1] - inter_size[1]) // 2)
+            new_img.paste(inter_img, box=upper_left)
+            new_img = np.array(new_img)
+
+        return ImageStim(stim.filename, data=new_img)
+
+
 class PillowImageFilter(ImageFilter):
 
     ''' Uses the ImageFilter module from PIL to run a pre-defined image enhancement

--- a/pliers/tests/filters/test_image_filters.py
+++ b/pliers/tests/filters/test_image_filters.py
@@ -43,6 +43,15 @@ def test_image_resizing_filter():
     # introduced when maintaining aspect ratio.
     assert (new_stim.data == 0).all(-1).sum() > 25000
 
+    assert ImageResizingFilter((24, 24), resample='nearest').resample == 0
+    assert ImageResizingFilter((24, 24), resample='bilinear').resample == 2
+    assert ImageResizingFilter((24, 24), resample='bicubic').resample == 3
+    assert ImageResizingFilter((24, 24), resample='lanczos').resample == 1
+    assert ImageResizingFilter((24, 24), resample='box').resample == 4
+    assert ImageResizingFilter((24, 24), resample='hamming').resample == 5
+    with pytest.raises(ValueError):
+        ImageResizingFilter((24, 24), resample='farthest')
+
 
 def test_pillow_image_filter_filter():
     stim = ImageStim(join(IMAGE_DIR, 'thai_people.jpg'))

--- a/pliers/tests/filters/test_image_filters.py
+++ b/pliers/tests/filters/test_image_filters.py
@@ -1,6 +1,7 @@
 from os.path import join
 from ..utils import get_test_data_path
 from pliers.filters import (ImageCroppingFilter,
+                            ImageResizingFilter,
                             PillowImageFilter)
 from pliers.stimuli import ImageStim
 import numpy as np
@@ -25,6 +26,22 @@ def test_image_cropping_filter():
     assert stim2.data.shape == (240, 240, 3)
     new_stim2 = filt2.transform(stim2)
     assert new_stim2.data.shape == (112, 240, 3)
+
+
+def test_image_resizing_filter():
+    stim = ImageStim(join(IMAGE_DIR, 'apple.jpg'))
+    size = (299, 299)
+    filt = ImageResizingFilter(size=size, maintain_aspect_ratio=False)
+    new_stim = filt.transform(stim)
+    # Test that only 2 pixels are black.
+    assert (new_stim.data == 0).all(-1).sum() < 100
+
+    filt2 = ImageResizingFilter(size=size, maintain_aspect_ratio=True)
+    new_stim = filt2.transform(stim)
+    assert new_stim.data.shape == (*size, 3)
+    # Test that many pixels are now black, because of the black border that is
+    # introduced when maintaining aspect ratio.
+    assert (new_stim.data == 0).all(-1).sum() > 25000
 
 
 def test_pillow_image_filter_filter():


### PR DESCRIPTION
This PR proposes adding an image resizing filter, which can optionally maintain aspect ratio. This is following up https://github.com/tyarkoni/pliers/pull/341#discussion_r279959595.

Here is some test code:

```python
import os
from pliers.filters import ImageResizingFilter
from pliers.stimuli import ImageStim
from pliers.tests.utils import get_test_data_path

image_path = os.path.join(get_test_data_path(), 'image', 'apple.jpg')
from PIL import Image

# Shape of the image is (288, 420, 3)
image = ImageStim(filename=image_path)

resizer = ImageResizingFilter((299, 299), maintain_aspect_ratio=False)
new_stim = resizer.transform(image)
print(new_stim.data.shape)
Image.fromarray(new_stim.data)

resizer = ImageResizingFilter((299, 299), maintain_aspect_ratio=True)
new_stim = resizer.transform(image)
print(new_stim.data.shape)
Image.fromarray(new_stim.data)
```

Output of first resizer:
![image](https://user-images.githubusercontent.com/17690870/57081155-2fa04a80-6cc2-11e9-9a84-2c949c2a8f02.png)

Output of second resizer:

![image](https://user-images.githubusercontent.com/17690870/57081219-4d6daf80-6cc2-11e9-88e5-b847401aa4d4.png)
