### PR TITLE
ENH: dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+docker/Dockerfile
+
+*.pyc
+*.DS_Store
+*~
+benchmarks/
+build/
+dist
+dist/*
+*.egg-info
+.cache
+doc/
+TODO.txt
+env.list
+docs/_build/
+docs/generated/
+.pytest_cache/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,9 @@ RUN apt-get update -qq \
     && pip install --no-cache-dir \
         --requirement requirements.txt \
         --requirement optional-dependencies.txt \
+    && python -m spacy download en_core_web_sm \
     && pip install --no-cache-dir --editable . \
+    && rm -rf ~/.cache/pip \
     && apt-get autoremove --purge -yq $tmp_pkgs \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,33 +1,22 @@
-FROM continuumio/miniconda3:4.5.11
-
+FROM python:3.6-slim
 ARG DEBIAN_FRONTEND="noninteractive"
-
-RUN apt-get -qq update \
-    && apt-get install -yq --no-install-recommends \
-      git \
-      graphviz \
-      libgraphviz-dev \
-      pkg-config \
-      tesseract-ocr \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
-ENV CONDA_DEPS="pip ffmpeg jupyter pytest pygraphviz numpy pandas pillow==2.9.0 requests scipy nltk six tqdm seaborn matplotlib pathos tensorflow contextlib2" \
-    PIP_DEPS="python-magic coveralls pytest-cov pysrt xlrd clarifai pytesseract moviepy==0.2.2.13 SpeechRecognition IndicoIo sklearn python-twitter gensim oauth2client google-api-python-client google-compute-engine librosa ipython"
-RUN conda info -a \
-    && conda config --set always_yes yes --set changeps1 no \
-    && conda config --add channels conda-forge \
-    && conda update -y -q conda \
-    && conda install $CONDA_DEPS \
-    && conda clean --all --yes \
-    && pip install --no-cache-dir $PIP_DEPS \
-    && python -c 'import imageio; imageio.plugins.ffmpeg.download()'
-
-WORKDIR /root/pliers
+WORKDIR /opt/pliers
 COPY . .
-RUN python setup.py install \
-    && python -m pliers.support.download
-
+RUN apt-get update -qq \
+    && tmp_pkgs="cmake gcc g++ libc6-dev libgraphviz-dev libmagic-dev make" \
+    && apt-get install -yq --no-install-recommends \
+        ffmpeg \
+        graphviz \
+        libmagic1 \
+        tesseract-ocr \
+        $tmp_pkgs \
+    && pip install --no-cache-dir \
+        --requirement requirements.txt \
+        --requirement optional-dependencies.txt \
+    && pip install --no-cache-dir --editable . \
+    && apt-get autoremove --purge -yq $tmp_pkgs \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --no-user-group --create-home --shell /bin/bash pliers
+USER pliers
 WORKDIR /work
-
-CMD ["/bin/bash"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,42 +1,33 @@
-FROM ubuntu:trusty
+FROM continuumio/miniconda3:4.5.11
 
-RUN apt-get update && apt-get install -y git
-RUN apt-get install -y software-properties-common
-RUN add-apt-repository ppa:joyard-nicolas/ffmpeg -y
-RUN apt-get -qq update
-RUN apt-get install -y ffmpeg tesseract-ocr
-RUN apt-get install -y wget
-RUN apt-get install -y graphviz libgraphviz-dev pkg-config
+ARG DEBIAN_FRONTEND="noninteractive"
 
-ENV MINICONDA_URL "https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh"
-ENV CONDA_DEPS "pip jupyter pytest numpy pandas pillow==2.9.0 requests scipy nltk six tqdm seaborn matplotlib pathos tensorflow contextlib2"
-WORKDIR /root
-ENV MINICONDA $HOME/miniconda
-ENV PATH "$MINICONDA/bin:$PATH"
-RUN wget $MINICONDA_URL -O miniconda.sh;
-RUN bash miniconda.sh -b -f -p $MINICONDA;
-RUN hash -r
-RUN conda info -a
-RUN conda config --set always_yes yes --set changeps1 no
-RUN conda config --add channels conda-forge
-RUN conda update -y conda
-RUN conda create -y -n py35 python=3.5 $CONDA_DEPS
+RUN apt-get -qq update \
+    && apt-get install -yq --no-install-recommends \
+      git \
+      graphviz \
+      libgraphviz-dev \
+      pkg-config \
+      tesseract-ocr \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN /bin/bash -c "source /miniconda/envs/py35/bin/activate py35 \
-  && pip install --upgrade --ignore-installed setuptools \
-  && pip install python-magic coveralls pytest-cov pygraphviz pysrt xlrd clarifai pytesseract moviepy==0.2.2.13 SpeechRecognition IndicoIo sklearn python-twitter gensim oauth2client google-api-python-client google-compute-engine librosa ipython"
+ENV CONDA_DEPS="pip ffmpeg jupyter pytest pygraphviz numpy pandas pillow==2.9.0 requests scipy nltk six tqdm seaborn matplotlib pathos tensorflow contextlib2" \
+    PIP_DEPS="python-magic coveralls pytest-cov pysrt xlrd clarifai pytesseract moviepy==0.2.2.13 SpeechRecognition IndicoIo sklearn python-twitter gensim oauth2client google-api-python-client google-compute-engine librosa ipython"
+RUN conda info -a \
+    && conda config --set always_yes yes --set changeps1 no \
+    && conda config --add channels conda-forge \
+    && conda update -y -q conda \
+    && conda install $CONDA_DEPS \
+    && conda clean --all --yes \
+    && pip install --no-cache-dir $PIP_DEPS \
+    && python -c 'import imageio; imageio.plugins.ffmpeg.download()'
 
-RUN /bin/bash -c 'source /miniconda/envs/py35/bin/activate py35 \
- && python -c "import imageio; imageio.plugins.ffmpeg.download()"'
-
-RUN git clone https://github.com/tyarkoni/pliers.git
 WORKDIR /root/pliers
-RUN /bin/bash -c 'source /miniconda/envs/py35/bin/activate py35 \
- && python setup.py install'
-RUN echo "if (tty -s); then \n\
-    source /miniconda/envs/py35/bin/activate py35\n\
-fi" >> /root/.bashrc
-RUN /bin/bash -c 'source /miniconda/envs/py35/bin/activate py35 \
- && python -m pliers.support.download'
-RUN apt-get install -y curl
+COPY . .
+RUN python setup.py install \
+    && python -m pliers.support.download
+
+WORKDIR /work
+
 CMD ["/bin/bash"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,12 +15,13 @@ RUN apt-get update -qq \
         --requirement optional-dependencies.txt \
         ipython \
         notebook \
-    && python -m spacy download en_core_web_sm \
     && pip install --no-cache-dir --editable . \
+    && python -m spacy download en_core_web_sm \
     && rm -rf ~/.cache/pip \
     && apt-get autoremove --purge -yq $tmp_pkgs \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && useradd --no-user-group --create-home --shell /bin/bash pliers
 USER pliers
+RUN python -m pliers.support.download
 WORKDIR /work

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,6 +13,8 @@ RUN apt-get update -qq \
     && pip install --no-cache-dir \
         --requirement requirements.txt \
         --requirement optional-dependencies.txt \
+        ipython \
+        notebook \
     && python -m spacy download en_core_web_sm \
     && pip install --no-cache-dir --editable . \
     && rm -rf ~/.cache/pip \

--- a/docker/README.md
+++ b/docker/README.md
@@ -9,9 +9,11 @@ but it works well enough.
 
 To use it:
 
-1. Build the docker container:
+1. Build the docker container. Run the following in the pliers root directory.
 
-    docker build -t pliers .
+    ```
+    docker build --tag pliers --file docker/Dockerfile .
+    ```
 
 2. Create a file that contains all of the relevant API keys, called env.list:
 


### PR DESCRIPTION
I tried building a pliers docker image with the current Dockerfile, but it raised an error during the build. So I decided to refactor the image. This introduces some major changes into the image, but I think it streamlines it nicely. The docker image in this PR bootstraps `python:3.6-slim` and installs all dependencies from pip.

This image also adds a non-root user, so you can use jupyter without having to pass in `--allow-root`, and things are a bit safer in general.