### PR TITLE
ENH: replace tensorflow extractor with more generic version.

### DIFF
--- a/pliers/extractors/__init__.py
+++ b/pliers/extractors/__init__.py
@@ -59,7 +59,7 @@ from .image import (BrightnessExtractor, SaliencyExtractor, SharpnessExtractor,
                     VibranceExtractor, FaceRecognitionFaceEncodingsExtractor,
                     FaceRecognitionFaceLandmarksExtractor,
                     FaceRecognitionFaceLocationsExtractor)
-from .models import TensorFlowKerasInceptionV3Extractor
+from .models import TensorFlowKerasApplicationExtractor
 from .text import (ComplexTextExtractor, DictionaryExtractor,
                    PredefinedDictionaryExtractor, LengthExtractor,
                    NumUniqueWordsExtractor, PartOfSpeechExtractor,
@@ -120,7 +120,7 @@ __all__ = [
     'MicrosoftVisionAPIImageTypeExtractor',
     'MicrosoftVisionAPIColorExtractor',
     'MicrosoftVisionAPIAdultExtractor',
-    'TensorFlowKerasInceptionV3Extractor',
+    'TensorFlowKerasApplicationExtractor',
     'ComplexTextExtractor',
     'DictionaryExtractor',
     'PredefinedDictionaryExtractor',

--- a/pliers/extractors/models.py
+++ b/pliers/extractors/models.py
@@ -1,67 +1,106 @@
 ''' Extractor classes based on pre-trained models. '''
 
 import numpy as np
-from PIL import Image
 from pliers.extractors.image import ImageExtractor
 from pliers.extractors.base import ExtractorResult
+from pliers.filters.image import ImageResizingFilter
 from pliers.utils import attempt_to_import, verify_dependencies
 
 
 tf = attempt_to_import('tensorflow')
+attempt_to_import('tensorflow.keras')
 
 
-def _resize_image(image, shape):
-    return np.array(
-        Image.fromarray(image).resize(shape, resample=Image.BICUBIC))
-
-
-class TensorFlowKerasInceptionV3Extractor(ImageExtractor):
+class TensorFlowKerasApplicationExtractor(ImageExtractor):
 
     ''' Labels objects in images using a pretrained Inception V3 architecture
     implemented in TensorFlow / Keras.
 
-    Images must be RGB and have shape (299, 299). Images will be resized (with
-    some distortion) if the shape is different.
+    Images must be RGB and be a certain shape. Different model architectures
+    may require different shapes, and images will be resized (with some
+    distortion) if the shape of the image is different.
 
     Args:
+        architecture (str): model architecture to use. One of 'vgg16', 'vgg19',
+            'resnet50', 'inception_resnetv2', 'inceptionv3', 'xception',
+            'densenet121', 'densenet169', 'nasnetlarge', or 'nasnetmobile'.
         weights (str): URL to download pre-trained weights. If None (default),
-            uses the pre-trained Inception V3 model (dated 2017-03-10) used in
-            Keras Applications.
+            uses the pre-trained weights trained on ImageNet used in Keras
+            Applications.
         num_predictions (int): Number of top predicted labels to retain for
             each image.
      '''
 
-    _log_attributes = ('weights', 'num_predictions')
+    _log_attributes = ('architecture', 'weights', 'num_predictions')
     VERSION = '1.0'
 
-    def __init__(self, weights=None, num_predictions=5):
+    def __init__(self,
+                 architecture='inceptionv3',
+                 weights=None,
+                 num_predictions=5):
         verify_dependencies(['tensorflow'])
-        super(TensorFlowKerasInceptionV3Extractor, self).__init__()
+        verify_dependencies(['tensorflow.keras'])
+        super(TensorFlowKerasApplicationExtractor, self).__init__()
+
+        # Model name: (model module, model function, required shape).
+        apps = tf.keras.applications
+        model_mapping = {
+            'vgg16': (apps.vgg16, apps.vgg16.VGG16, (224, 224, 3)),
+            'vgg19': (apps.vgg19, apps.VGG19, (224, 224, 3)),
+            'resnet50': (apps.resnet50, apps.resnet50.ResNet50, (224, 224, 3)),
+            'inception_resnetv2': (
+                apps.inception_resnet_v2,
+                apps.inception_resnet_v2.InceptionResNetV2, (299, 299, 3)),
+            'inceptionv3': (
+                apps.inception_v3, apps.inception_v3.InceptionV3,
+                (299, 299, 3)),
+            'xception': (apps.xception, apps.xception.Xception, (299, 299, 3)),
+            'densenet121': (
+                apps.densenet, apps.densenet.DenseNet121, (224, 224, 3)),
+            'densenet169': (
+                apps.densenet, apps.densenet.DenseNet169, (224, 224, 3)),
+            'densenet201': (
+                apps.densenet, apps.densenet.DenseNet201, (224, 224, 3)),
+            'nasnetlarge': (
+                apps.nasnet, apps.nasnet.NASNetLarge, (331, 331, 3)),
+            'nasnetmobile': (
+                apps.nasnet, apps.nasnet.NASNetMobile, (224, 224, 3)),
+        }
         if weights is None:
             weights = 'imagenet'
+        if architecture.lower() not in model_mapping.keys():
+            raise ValueError(
+                "Unknown architecture '{}'. Available arhitectures are '{}'."
+                .format(architecture, "', '".join(model_mapping.keys())))
+
+        self.architecture = architecture.lower()
         self.weights = weights
         self.num_predictions = num_predictions
+
+        # The preprocessing and decoding functions are in the module.
+        self._model_module = model_mapping[self.architecture][0]
         # Instantiating the model also downloads the weights to a cache.
-        self.model = tf.keras.applications.inception_v3.InceptionV3(
-            weights=self.weights)
+        self.model = model_mapping[self.architecture][1](weights=self.weights)
+        self._required_shape = model_mapping[self.architecture][2]
 
     def _extract(self, stim):
-        required_shape = (299, 299, 3)
         x = stim.data
         if x.ndim != 3:
-            raise ValueError("Stim data must have rank 3 but got rank {}".format(x.ndim))
-        if x.shape != required_shape:
-            x = _resize_image(x, required_shape[:-1])
+            raise ValueError(
+                "Stim data must have rank 3 but got rank {}".format(x.ndim))
+        if x.shape != self._required_shape:
+            resizer = ImageResizingFilter(size=self._required_shape[:-1])
+            x = resizer.transform(stim).data
         # Add batch dimension.
         x = x[None]
         # Normalize the features.
-        x = tf.keras.applications.inception_v3.preprocess_input(x)
+        x = self._model_module.preprocess_input(x)
         preds = self.model.predict(x, batch_size=1)
 
         # This produces a nested list. There is one sub-list per sample in the
         # batch, and each sub-list contains `self.num_predictions` tuples with
         # `(ID, human-readable-label, probability)`.
-        decoded = tf.keras.applications.inception_v3.decode_predictions(
+        decoded = self._model_module.decode_predictions(
             preds, top=self.num_predictions)
 
         # We assume there is only one sample in the batch.

--- a/pliers/tests/extractors/test_image_extractors.py
+++ b/pliers/tests/extractors/test_image_extractors.py
@@ -69,6 +69,8 @@ def test_tensorflow_keras_application_extractor():
     assert np.isclose(true, pred, 1e-05)
     assert 4.2 in df[('onset', np.nan)].values
     assert 1 in df[('duration', np.nan)].values
+    with pytest.raises(ValueError):
+        TensorFlowKerasApplicationExtractor(architecture='foo')
 
 
 def test_face_recognition_landmarks_extractor():

--- a/pliers/tests/extractors/test_image_extractors.py
+++ b/pliers/tests/extractors/test_image_extractors.py
@@ -4,7 +4,7 @@ from pliers.extractors import (BrightnessExtractor,
                                SharpnessExtractor,
                                VibranceExtractor,
                                SaliencyExtractor,
-                               TensorFlowKerasInceptionV3Extractor,
+                               TensorFlowKerasApplicationExtractor,
                                FaceRecognitionFaceLandmarksExtractor,
                                FaceRecognitionFaceLocationsExtractor,
                                FaceRecognitionFaceEncodingsExtractor)
@@ -54,19 +54,19 @@ def test_saliency_extractor():
     assert np.isclose(sf, 0.27461971, 1e-5)
 
 
-def test_tensorflow_keras_inception_v3_extractor():
+def test_tensorflow_keras_application_extractor():
     imgs = [join(IMAGE_DIR, f) for f in ['apple.jpg', 'obama.jpg']]
     imgs = [ImageStim(im, onset=4.2, duration=1) for im in imgs]
-    ext = TensorFlowKerasInceptionV3Extractor()
+    ext = TensorFlowKerasApplicationExtractor()
     results = ext.transform(imgs)
     df = merge_results(results, format='wide', extractor_names='multi')
     assert df.shape == (2, 19)
     true = 0.9737075
-    pred = df['TensorFlowKerasInceptionV3Extractor'].loc[0, 'Granny_Smith']
-    np.isclose(true, pred, 1e-05)
+    pred = df['TensorFlowKerasApplicationExtractor'].loc[0, 'Granny_Smith']
+    assert np.isclose(true, pred, 1e-05)
     true = 0.64234024
-    pred = df['TensorFlowKerasInceptionV3Extractor'].loc[1, 'Windsor_tie']
-    np.isclose(true, pred, 1e-05)
+    pred = df['TensorFlowKerasApplicationExtractor'].loc[1, 'Windsor_tie']
+    assert np.isclose(true, pred, 1e-05)
     assert 4.2 in df[('onset', np.nan)].values
     assert 1 in df[('duration', np.nan)].values
 


### PR DESCRIPTION
This class accepts a model architecture string, and will use that pre-trained model from `tensorflow.keras.applications`. These changes also check whether `tensorflow.keras` is available. For image resizing, `pliers.filters.ImageResizingFilter` is used. The architecture 'inceptionv3' is the default.

Here is code for testing:

```python
import os
from pliers.extractors import TensorFlowKerasApplicationExtractor
from pliers.stimuli import ImageStim
from pliers.tests.utils import get_test_data_path

path = os.path.join(get_test_data_path(), 'image', 'apple.jpg')
image = ImageStim(path)
ext = TensorFlowKerasApplicationExtractor(architecture='inceptionv3')
result = ext.transform(image)
```