### PR TITLE
ENH: precreate non standard /data /backup directories in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,6 +22,9 @@ RUN apt-get update -qq \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && useradd --no-user-group --create-home --shell /bin/bash pliers
+# Empty top level directories to facilitate use of the image in singularity
+# on a box with kernel lacking overlay FS support
+RUN mkdir -p /data /backup
 USER pliers
 RUN python -m pliers.support.download
 WORKDIR /work


### PR DESCRIPTION
This is to facilitate reuse of the docker image when fetched by singularity
on a system with an elderly kernel built without support of overlays and thus
requiring those directories (present on our HPC) to be present within image

No hurt feelings if rejected -- just wanted to check for an easy way out for myself ;)