### PR TITLE
ENH: Dockerfile - chmod to guarantee availability, and test global installation via import pliers

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,6 +2,7 @@ FROM python:3.6-slim
 ARG DEBIAN_FRONTEND="noninteractive"
 WORKDIR /opt/pliers
 COPY . .
+RUN chmod a+rX -R .
 RUN apt-get update -qq \
     && tmp_pkgs="cmake gcc g++ libc6-dev libgraphviz-dev libmagic-dev make" \
     && apt-get install -yq --no-install-recommends \


### PR DESCRIPTION
the first call `python -m pliers.support.download` is done within source code tree, so mileage could vary from calling from outside