### PR TITLE
[WIP] safeguard against keyerror in clarifai face detection

### DIFF
--- a/pliers/extractors/api/clarifai.py
+++ b/pliers/extractors/api/clarifai.py
@@ -98,7 +98,7 @@ class ClarifaiAPIExtractor(APITransformer):
     def _parse_annotations(self, annotation):
         data_dict = {}
         # check whether the model is the face detection model
-        if self.model_name == 'a403429f2ddf4b49b307e318f00e528b':
+        if self.model_name == 'face':
             # if a face was detected, get at least the boundaries
             if annotation['data']:
                 for k, v in annotation['data']['regions'][0]['region_info']['bounding_box'].items():

--- a/pliers/extractors/api/clarifai.py
+++ b/pliers/extractors/api/clarifai.py
@@ -97,8 +97,16 @@ class ClarifaiAPIExtractor(APITransformer):
 
     def _parse_annotations(self, annotation):
         data_dict = {}
-        for tag in annotation['data']['concepts']:
-            data_dict[tag['name']] = tag['value']
+        # check whether the model is the face detection model
+        if self.model_name == 'a403429f2ddf4b49b307e318f00e528b':
+            # if a face was detected, get at least the boundaries
+            if annotation['data']:
+                for k, v in annotation['data']['regions'][0]['region_info']['bounding_box'].items():
+                    data_dict[k] = v
+            # return an empty dict if there was no face
+        else:
+            for tag in annotation['data']['concepts']:
+                data_dict[tag['name']] = tag['value']
         return data_dict
 
 

--- a/pliers/tests/extractors/api/test_clarifai_extractors.py
+++ b/pliers/tests/extractors/api/test_clarifai_extractors.py
@@ -44,6 +44,16 @@ def test_clarifai_api_extractor():
     ext = ClarifaiAPIImageExtractor(api_key='nogood')
     assert not ext.validate_keys()
 
+    stim = ImageStim(join(IMAGE_DIR, 'obama.jpg'))
+    result = ClarifaiAPIImageExtractor(model='face').transform(stim).to_df()
+    keys_to_check = ['top_row', 'left_col', 'bottom_row', 'right_col']
+    assert [k not in result.keys() for k in keys_to_check]
+    assert all([result[k][0] != np.nan for k in result if k in keys_to_check])
+
+    stim = ImageStim(join(IMAGE_DIR, 'aspect_ratio_fail.jpg'))
+    result = ClarifaiAPIImageExtractor(model='face').transform(stim).to_df()
+    assert [k in result.keys() for k in keys_to_check]
+
 
 @pytest.mark.requires_payment
 @pytest.mark.skipif("'CLARIFAI_API_KEY' not in os.environ")
@@ -97,3 +107,14 @@ def test_clarifai_api_video_extractor():
     assert result['duration'][0] == 1.0
     # because of the behavior described above—handle both cases
     assert np.isclose(result['duration'][5], 0.57) or result['duration'][6] == 0
+
+    ext = ClarifaiAPIVideoExtractor(model='face')
+    result = ext.transform(stim).to_df()
+    keys_to_check = ['top_row', 'left_col', 'bottom_row', 'right_col']
+    assert [k not in result.keys() for k in keys_to_check]
+    assert all([result[k][0] == np.nan for k in result if k in keys_to_check])
+
+    stim = VideoStim(join(VIDEO_DIR, 'obama_speech.mp4'))
+    result = ext.transform(stim).to_df()
+    keys_to_check = ['top_row', 'left_col', 'bottom_row', 'right_col']
+    assert [k in result.keys() for k in keys_to_check]

--- a/pliers/tests/extractors/api/test_clarifai_extractors.py
+++ b/pliers/tests/extractors/api/test_clarifai_extractors.py
@@ -100,8 +100,9 @@ def test_clarifai_api_video_extractor():
     # This should actually be 6, in principle, because the clip is < 6 seconds,
     # but the Clarifai API is doing weird things. See comment in
     # ClarifaiAPIVideoExtractor._to_df() for further explanation.
-    assert result.shape[1] == 29
     assert result.shape[0] in (6, 7)
+    # Changes sometimes, so use a range
+    assert result.shape[1] > 25 and result.shape[1] < 30
     assert result['toy'][0] > 0.5
     assert result['onset'][1] == 1.0
     assert result['duration'][0] == 1.0


### PR DESCRIPTION
Toying around with the face detection models of clarifai, I noticed that while the extraction works, the transformation into a dataframe with ``_to_df()`` fails due to KeyErrors.
This is a very basic safe guard that checks whether the model used for the clarifai client is a Face Detection model (they identify it by this character string) and if so, returns the face region boundaries as a dataframe if a face is present and nothing if no face is present.

I had plenty of problems testing all if this locally, because I exceeded my free request limit, so I'm PRing a work in progress for further discussion about alternatives, or any other improvements.