### PR TITLE
[WIP] Adjust clarifai face detection model for multi-face stimuli

### DIFF
--- a/pliers/extractors/api/clarifai.py
+++ b/pliers/extractors/api/clarifai.py
@@ -184,6 +184,9 @@ class ClarifaiAPIImageExtractor(ClarifaiAPIExtractor, BatchTransformerMixin,
         return extractions
 
     def _to_df(self, result):
+        if self.model_name == 'face':
+            # is a list already, no need to wrap it in one
+            return pd.DataFrame(self._parse_annotations(result._data))
         return pd.DataFrame([self._parse_annotations(result._data)])
 
 

--- a/pliers/tests/extractors/api/test_clarifai_extractors.py
+++ b/pliers/tests/extractors/api/test_clarifai_extractors.py
@@ -54,6 +54,10 @@ def test_clarifai_api_extractor():
     result = ClarifaiAPIImageExtractor(model='face').transform(stim).to_df()
     assert [k in result.keys() for k in keys_to_check]
 
+    # check whether a multi-face image has the appropriate amount of rows
+    stim = ImageStim(join(IMAGE_DIR, 'thai_people.jpg'))
+    result = ClarifaiAPIImageExtractor(model='face').transform(stim).to_df()
+    assert len(result) == 4
 
 @pytest.mark.requires_payment
 @pytest.mark.skipif("'CLARIFAI_API_KEY' not in os.environ")
@@ -119,3 +123,5 @@ def test_clarifai_api_video_extractor():
     result = ext.transform(stim).to_df()
     keys_to_check = ['top_row', 'left_col', 'bottom_row', 'right_col']
     assert [k in result.keys() for k in keys_to_check]
+    # check if we return more than 1 row per second of face bounding boxes
+    assert len(result) > 6


### PR DESCRIPTION
My previous PR (#355) adjusted the clarifai face detection model to work only with single face images. In the case of more than one image, only the last image would be returned. This PR returns all detected faces in an image or video in a multi-row data frame.
I've also added basic tests that check whether more than a single face is returned in the case of multiple faces in the stimuli.

Copying the google API face extraction, I've added a parameter to return only the first face, if desired (`handle_annotations'), but I'm not using that anywhere so far (mainly because I can't find it used for Google anywhere).