### PR TITLE
fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,7 @@ matrix:
 before_install:
 - openssl aes-256-cbc -K $encrypted_a0a62c26415d_key -iv $encrypted_a0a62c26415d_iv
   -in pliers/tests/credentials/google.json.enc -out pliers/tests/credentials/google.json -d || true
-- sudo add-apt-repository ppa:mc3man/trusty-media -y
-- sudo apt-get -qq update
-- sudo apt-get install libmp3lame-dev ffmpeg tesseract-ocr graphviz cmake
+- sudo apt-get install libavformat-dev libavfilter-dev libavdevice-dev ffmpeg libmp3lame-dev tesseract-ocr graphviz cmake
 - export MINICONDA=$HOME/miniconda
 - export PATH="$MINICONDA/bin:$PATH"
 - wget $MINICONDA_URL -O miniconda.sh;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: trusty
+dist: xenial
 language: python
 matrix:
   include:

--- a/optional-dependencies.txt
+++ b/optional-dependencies.txt
@@ -14,7 +14,7 @@ pygraphviz
 pysrt
 pytesseract
 python-twitter
-scikit-learn<=0.21
+scikit-learn
 seaborn
 spacy
 SpeechRecognition>=3.6.0

--- a/optional-dependencies.txt
+++ b/optional-dependencies.txt
@@ -14,7 +14,7 @@ pygraphviz
 pysrt
 pytesseract
 python-twitter
-scikit-learn
+scikit-learn<=0.21
 seaborn
 spacy
 SpeechRecognition>=3.6.0

--- a/pliers/converters/base.py
+++ b/pliers/converters/base.py
@@ -6,7 +6,7 @@ from six import with_metaclass
 from pliers.utils import listify, EnvironmentKeyMixin
 from pliers import config
 import pliers
-
+import inspect
 
 class Converter(with_metaclass(ABCMeta, Transformer)):
 
@@ -48,7 +48,7 @@ def get_converter(in_type, out_type, *args, **kwargs):
 
     for name in convs:
         cls = getattr(pliers.converters, name)
-        if not issubclass(cls, Converter):
+        if not inspect.isclass(cls) or not issubclass(cls, Converter):
             continue
 
         available = cls.available if issubclass(

--- a/pliers/converters/base.py
+++ b/pliers/converters/base.py
@@ -8,6 +8,7 @@ from pliers import config
 import pliers
 import inspect
 
+
 class Converter(with_metaclass(ABCMeta, Transformer)):
 
     ''' Base class for Converters.'''

--- a/pliers/datasets/dictionaries.json
+++ b/pliers/datasets/dictionaries.json
@@ -151,9 +151,9 @@
         "title": "The Calgary semantic decision project: concrete/abstract decision data for 10,000 English words",
         "description_url": "https://psyc.ucalgary.ca/languageprocessing/node/22",
         "source": "Pexman, P. M., Heard, A., Lloyd, E., & Yap, M. J. (2017). The Calgary semantic decision project: concrete/abstract decision data for 10,000 English words. Behavior Research Methods, 49(2), 407-417.",
-        "url": "https://psychology.ucalgary.ca/languageprocessing/sites/psyc.ucalgary.ca.languageprocessing/files/calgary_sdt_itemwise_data.xls",
+        "url": "https://static-content.springer.com/esm/art%3A10.3758%2Fs13428-016-0720-6/MediaObjects/13428_2016_720_MOESM2_ESM.xlsx",
         "license": "",
-        "format": "xls",
+        "format": "xlsx",
         "language": "english",
         "columns": ["VersionNum", "WordType", "Block", "Word_ID_unique", "RTclean_mean", "RTclean_sd", "Rtclean_n", "zRTclean_mean", "zRTclean_sd", "zRTclean_n", "ACC", "ACC_n", "Concrete_rating"]
     },

--- a/pliers/datasets/text.py
+++ b/pliers/datasets/text.py
@@ -36,7 +36,7 @@ def _download_dictionary(url, format, rename):
     with open(_file, 'wb') as f:
         f.write(r.content)
 
-    if zipfile.is_zipfile(_file):
+    if format != 'xlsx' and zipfile.is_zipfile(_file):
         with zipfile.ZipFile(_file) as zf:
             source = zf.namelist()[0]
             zf.extract(source, tmpdir)

--- a/pliers/extractors/text.py
+++ b/pliers/extractors/text.py
@@ -288,7 +288,7 @@ class TextVectorizerExtractor(BatchTransformerMixin, TextExtractor):
 
     def __init__(self, vectorizer=None, *vectorizer_args, **vectorizer_kwargs):
         verify_dependencies(['sklearn_text'])
-        if isinstance(vectorizer, sklearn_text._VectorizerMixin):
+        if isinstance(vectorizer, sklearn_text.CountVectorizer):
             self.vectorizer = vectorizer
         elif isinstance(vectorizer, str):
             vec = getattr(sklearn_text, vectorizer)

--- a/pliers/extractors/text.py
+++ b/pliers/extractors/text.py
@@ -23,7 +23,7 @@ from six import string_types
 keyedvectors = attempt_to_import('gensim.models.keyedvectors', 'keyedvectors',
                                  ['KeyedVectors'])
 sklearn_text = attempt_to_import('sklearn.feature_extraction.text', 'sklearn_text',
-                                 ['VectorizerMixin', 'CountVectorizer'])
+                                 ['_VectorizerMixin', 'CountVectorizer'])
 spacy = attempt_to_import('spacy')
 
 
@@ -288,7 +288,7 @@ class TextVectorizerExtractor(BatchTransformerMixin, TextExtractor):
 
     def __init__(self, vectorizer=None, *vectorizer_args, **vectorizer_kwargs):
         verify_dependencies(['sklearn_text'])
-        if isinstance(vectorizer, sklearn_text.VectorizerMixin):
+        if isinstance(vectorizer, sklearn_text._VectorizerMixin):
             self.vectorizer = vectorizer
         elif isinstance(vectorizer, str):
             vec = getattr(sklearn_text, vectorizer)

--- a/pliers/extractors/text.py
+++ b/pliers/extractors/text.py
@@ -23,7 +23,7 @@ from six import string_types
 keyedvectors = attempt_to_import('gensim.models.keyedvectors', 'keyedvectors',
                                  ['KeyedVectors'])
 sklearn_text = attempt_to_import('sklearn.feature_extraction.text', 'sklearn_text',
-                                 ['_VectorizerMixin', 'CountVectorizer'])
+                                 ['CountVectorizer'])
 spacy = attempt_to_import('spacy')
 
 

--- a/pliers/tests/extractors/test_text_extractors.py
+++ b/pliers/tests/extractors/test_text_extractors.py
@@ -204,7 +204,7 @@ def test_spacy_token_extractor():
 
     assert result['text'][1] == 'is'
     assert result['lemma_'][1].lower() == 'be'
-    assert result['pos_'][1] in ['AUX', 'VERB']
+    assert result['pos_'][1] == 'AUX'
     assert result['tag_'][1] == 'VBZ'
     assert result['dep_'][1] == 'ROOT'
     assert result['shape_'][1] == 'xx'

--- a/pliers/tests/extractors/test_text_extractors.py
+++ b/pliers/tests/extractors/test_text_extractors.py
@@ -204,7 +204,7 @@ def test_spacy_token_extractor():
 
     assert result['text'][1] == 'is'
     assert result['lemma_'][1].lower() == 'be'
-    assert result['pos_'][1] == 'VERB'
+    assert result['pos_'][1] in ['AUX', 'VERB']
     assert result['tag_'][1] == 'VBZ'
     assert result['dep_'][1] == 'ROOT'
     assert result['shape_'][1] == 'xx'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 python-magic
-numpy~=1.8
-nltk~=3.0
-moviepy>=0.2.3.5
-pandas~=0.20.0
+numpy>=1.13
+nltk>=3.0
+moviepy>=0.2
+pandas~=0.25
 pillow
 requests
-scipy~=0.13
-imageio~=2.3
+scipy>=0.13
+imageio>=2.3
 six
 tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ python-magic
 numpy>=1.8.1
 nltk>=3.0.0
 moviepy>=0.2.3.5
-pandas=0.25.0
+pandas>=0.20.0
 pillow
 requests
 scipy>=0.13.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 python-magic
-numpy~=1.8
-nltk~=3.0
-moviepy~=0.2
+numpy>=1.8.1
+nltk>=3.0.0
+moviepy>=0.2.3.5
 pandas~=0.20
 pillow
 requests
-scipy~=0.13
-imageio~=2.3
+scipy>=0.13.3
+imageio>=2.3.0
 six
 tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 python-magic
-numpy>=1.8.1
-nltk>=3.0.0
-moviepy>=0.2.3.5
+numpy~=1.8
+nltk~=3.0
+moviepy~=0.2
 pandas~=0.20
 pillow
 requests
-scipy>=0.13.3
-imageio>=2.3.0
+scipy~=0.13
+imageio~=2.3
 six
 tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ python-magic
 numpy>=1.8.1
 nltk>=3.0.0
 moviepy>=0.2.3.5
-pandas~=0.20
+pandas=0.25.0
 pillow
 requests
 scipy>=0.13.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ python-magic
 numpy>=1.8.1
 nltk>=3.0.0
 moviepy>=0.2.3.5
-pandas>=0.20.0
+pandas~=0.20
 pillow
 requests
 scipy>=0.13.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 python-magic
-numpy>=1.8.1
-nltk>=3.0.0
+numpy~=1.8
+nltk~=3.0
 moviepy>=0.2.3.5
-pandas>=0.20.0
+pandas~=0.20.0
 pillow
 requests
-scipy>=0.13.3
-imageio>=2.3.0
+scipy~=0.13
+imageio~=2.3
 six
 tqdm


### PR DESCRIPTION
Fixes:
- `SpaCy Extractor`. SpaCy has updated mapping between UD tags ("tag" feature) and the coarser "pos" feature. Mapping for auxiliary updated to UD-tag "VBZ" -> "AUX" instead of "VBZ" -> "VERB". For reference, the tag-to-pos mapping scheme is defined [here](https://github.com/explosion/spaCy/blob/master/spacy/lang/en/morph_rules.py) and the relevant commit where new word-specific rules are defined is [here](https://github.com/explosion/spaCy/commit/04395ffa49409f669147168c8966ac21335cbb4d#diff-452945f82ac41b4b16bd9d7fc658cc1a).
- `PredefinedDictionaryExtractor`: link to Calgary Lexical Decision dataset was broken, now replaced with active link. 
- `_download_dictionary` method edited so to except xlsx files from zipfiles routine.
- Set `pandas` version to < 1.0.0 (should fix API incompatibilities later)
- Drop Python 3.5 from Travis, add 3.7 (Miniconda related)
- Check if `cls` is a class before passing to `issubclass` (for Python 3.7)
- Remove ffmpeg ppa from Travis config (PPA no longer works, used alternative source)
- Edit `TextVectorizerExtractor`. `TfidfVectorizer` from `sklearn.test` is now instance of class `CounterExtractor`, as `VectorizerMixin` class has been dropped in v0.22.