### PR TITLE
Split pytest into multiple calls to avoid memory limits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,10 @@ before_script:
 - python -m pliers.support.download
 - python -m spacy download en_core_web_sm
 script:
-- py.test --pyargs pliers --cov-report term-missing --cov=pliers -m "not requires_payment"
+- py.test pliers/tests/test_* --cov-report term-missing --cov=pliers -m "not requires_payment"
+- py.test pliers/tests/extractors --cov-report term-missing --cov=pliers -m "not requires_payment" --cov-append
+- py.test pliers/tests/converters --cov-report term-missing --cov=pliers -m "not requires_payment" --cov-append
+- py.test pliers/tests/filters --cov-report term-missing --cov=pliers -m "not requires_payment" --cov-append
 after_success:
 - coveralls
 before_cache:


### PR DESCRIPTION
Fixes timing out travis tests by splitting up the py.test calls into four. 