### PR TITLE
Limit pytest outputs for readability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,9 +47,9 @@ before_script:
 - python -m pliers.support.download
 - python -m spacy download en_core_web_sm
 script:
-- py.test pliers/tests/test_* --cov=pliers --cov-report= -m "not requires_payment"
-- py.test pliers/tests/extractors --cov=pliers --cov-report= -m "not requires_payment" --cov-append
-- py.test pliers/tests/converters pliers/tests/filters --cov=pliers--cov-report=  -m "not requires_payment" --cov-append
+- py.test pliers/tests/test_* --cov=pliers --cov-report= -m "not requires_payment" -W ignore::UserWarning
+- py.test pliers/tests/extractors --cov=pliers --cov-report= -m "not requires_payment" --cov-append -W ignore::UserWarning
+- py.test pliers/tests/converters pliers/tests/filters --cov=pliers --cov-report= -m "not requires_payment" --cov-append -W ignore::UserWarning
 after_success:
 - coveralls
 before_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,9 +47,8 @@ before_script:
 - python -m pliers.support.download
 - python -m spacy download en_core_web_sm
 script:
-- py.test pliers/tests/test_* --cov=pliers --cov-report= -m "not requires_payment" -W ignore::UserWarning
+- py.test pliers/tests/test_* pliers/tests/converters pliers/tests/filters --cov=pliers --cov-report= -m "not requires_payment" -W ignore::UserWarning
 - py.test pliers/tests/extractors --cov=pliers --cov-report= -m "not requires_payment" --cov-append -W ignore::UserWarning
-- py.test pliers/tests/converters pliers/tests/filters --cov=pliers --cov-report= -m "not requires_payment" --cov-append -W ignore::UserWarning
 after_success:
 - coveralls
 before_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,10 +47,9 @@ before_script:
 - python -m pliers.support.download
 - python -m spacy download en_core_web_sm
 script:
-- py.test pliers/tests/test_* --cov=pliers -m "not requires_payment"
-- py.test pliers/tests/extractors --cov=pliers -m "not requires_payment" --cov-append
-- py.test pliers/tests/converters --cov=pliers -m "not requires_payment" --cov-append
-- py.test pliers/tests/filters --cov=pliers -m "not requires_payment" --cov-append
+- py.test pliers/tests/test_* --cov=pliers --cov-report= -m "not requires_payment"
+- py.test pliers/tests/extractors --cov=pliers --cov-report= -m "not requires_payment" --cov-append
+- py.test pliers/tests/converters pliers/tests/filters --cov=pliers--cov-report=  -m "not requires_payment" --cov-append
 after_success:
 - coveralls
 before_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,10 +47,10 @@ before_script:
 - python -m pliers.support.download
 - python -m spacy download en_core_web_sm
 script:
-- py.test pliers/tests/test_* --cov-report term-missing --cov=pliers -m "not requires_payment"
-- py.test pliers/tests/extractors --cov-report term-missing --cov=pliers -m "not requires_payment" --cov-append
-- py.test pliers/tests/converters --cov-report term-missing --cov=pliers -m "not requires_payment" --cov-append
-- py.test pliers/tests/filters --cov-report term-missing --cov=pliers -m "not requires_payment" --cov-append
+- py.test pliers/tests/test_* --cov=pliers -m "not requires_payment"
+- py.test pliers/tests/extractors --cov=pliers -m "not requires_payment" --cov-append
+- py.test pliers/tests/converters --cov=pliers -m "not requires_payment" --cov-append
+- py.test pliers/tests/filters --cov=pliers -m "not requires_payment" --cov-append
 after_success:
 - coveralls
 before_cache:

--- a/pliers/tests/conftest.py
+++ b/pliers/tests/conftest.py
@@ -29,7 +29,7 @@ def pytest_runtest_teardown(item):
     gc.collect()
 
 
-LEAK_LIMIT = 15 * 1024 * 1024
+LEAK_LIMIT = 75 * 1024 * 1024
 
 
 def pytest_terminal_summary(terminalreporter):
@@ -40,8 +40,8 @@ def pytest_terminal_summary(terminalreporter):
             leaked = end_entry.consumed_ram - start_entry.consumed_ram
             if leaked > LEAK_LIMIT:
                 terminalreporter.write('LEAKED {}MB in {}\n'.format(
-                    leaked / 1024 / 1024, nodeid))
+                    round(leaked / 1024 / 1024, 2), nodeid))
                 terminalreporter.write('MEMORY ENDED AT: {}MB in {}\n'.format(
-                    end_entry.consumed_ram / 1024 / 1024, nodeid))
+                    round(end_entry.consumed_ram / 1024 / 1024, 2), nodeid))
         except:
             pass

--- a/pliers/tests/conftest.py
+++ b/pliers/tests/conftest.py
@@ -29,7 +29,7 @@ def pytest_runtest_teardown(item):
     gc.collect()
 
 
-LEAK_LIMIT = 5 * 1024 * 1024
+LEAK_LIMIT = 15 * 1024 * 1024
 
 
 def pytest_terminal_summary(terminalreporter):


### PR DESCRIPTION
- Try to make the outputs of Travis as readable as possible (clean up clutter)