### PR TITLE
Fix index cols for no _to_df

### DIFF
--- a/pliers/extractors/base.py
+++ b/pliers/extractors/base.py
@@ -125,7 +125,7 @@ class ExtractorResult(object):
         if features is not None:
             index_cols = list(set(df.columns) - set(features))
         else:
-            index_cols = list(set(df.columns))
+            index_cols = []
 
         if hasattr(self, '_onsets'):
             onsets = np.array(self._onsets)


### PR DESCRIPTION
A small bug in the `to_df `function which was causing incorrect `df` for some Extractors (`Clarifai` in this instance).

Only applies to those Extractors with no `_to_df` function and outputs in long format. 

I accidentally made all the columns index_cols include the feature names itself for that case. 