### PR TITLE
Drop vestigial Python 2 code

### DIFF
--- a/pliers/config.py
+++ b/pliers/config.py
@@ -4,7 +4,7 @@ manipulating them. '''
 import json
 from os.path import join, expanduser, exists
 import os
-from six import string_types
+
 
 __all__ = ['set_option', 'set_options', 'get_option']
 
@@ -52,7 +52,7 @@ def get_option(key):
 
 
 def from_file(filenames, error_on_missing=True):
-    if isinstance(filenames, string_types):
+    if isinstance(filenames, str):
         filenames = [filenames]
     for f in filenames:
         if exists(f):

--- a/pliers/converters/api/ibm.py
+++ b/pliers/converters/api/ibm.py
@@ -69,7 +69,7 @@ class IBMSpeechAPIConverter(APITransformer, AudioToTextConverter):
             self._send_request(request)
             return True
         except Exception as e:
-            logging.warn(str(e))
+            logging.warning(str(e))
             return False
 
     def _convert(self, audio):

--- a/pliers/converters/api/ibm.py
+++ b/pliers/converters/api/ibm.py
@@ -4,13 +4,14 @@ import os
 import base64
 import json
 import logging
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+from urllib.error import URLError, HTTPError
+
 from pliers.stimuli.text import TextStim, ComplexTextStim
 from pliers.utils import attempt_to_import, verify_dependencies
 from pliers.converters.audio import AudioToTextConverter
 from pliers.transformers.api import APITransformer
-from urllib.parse import urlencode
-from urllib.request import Request, urlopen
-from urllib.error import URLError, HTTPError
 
 sr = attempt_to_import('speech_recognition', 'sr')
 

--- a/pliers/converters/api/revai.py
+++ b/pliers/converters/api/revai.py
@@ -57,11 +57,11 @@ class RevAISpeechAPIConverter(APITransformer, AudioToTextConverter):
             if account.balance_seconds > 0:
                 return True
             else:
-                logging.warn("Insufficient balance for Rev.ai speech "
+                logging.warning("Insufficient balance for Rev.ai speech "
                              "converter: {}".format(account.balance_seconds))
                 return False
         except Exception as e:
-            logging.warn(str(e))
+            logging.warning(str(e))
             return False
 
     def _convert(self, audio):

--- a/pliers/converters/api/wit.py
+++ b/pliers/converters/api/wit.py
@@ -75,5 +75,5 @@ class WitTranscriptionConverter(SpeechRecognitionAPIConverter):
             urlopen(request)
             return True
         except HTTPError as e:
-            logging.warn(str(e))
+            logging.warning(str(e))
             return False

--- a/pliers/converters/api/wit.py
+++ b/pliers/converters/api/wit.py
@@ -7,8 +7,8 @@ from pliers.stimuli.text import ComplexTextStim
 from pliers.utils import attempt_to_import, verify_dependencies
 from pliers.converters.audio import AudioToTextConverter
 from pliers.transformers.api import APITransformer
-from six.moves.urllib.request import Request, urlopen
-from six.moves.urllib.error import HTTPError
+from urllib.request import Request, urlopen
+from urllib.error import HTTPError
 
 sr = attempt_to_import('speech_recognition', 'sr')
 

--- a/pliers/converters/api/wit.py
+++ b/pliers/converters/api/wit.py
@@ -3,12 +3,13 @@
 import logging
 import os
 from abc import abstractproperty
+from urllib.request import Request, urlopen
+from urllib.error import HTTPError
+
 from pliers.stimuli.text import ComplexTextStim
 from pliers.utils import attempt_to_import, verify_dependencies
 from pliers.converters.audio import AudioToTextConverter
 from pliers.transformers.api import APITransformer
-from urllib.request import Request, urlopen
-from urllib.error import HTTPError
 
 sr = attempt_to_import('speech_recognition', 'sr')
 

--- a/pliers/converters/base.py
+++ b/pliers/converters/base.py
@@ -2,14 +2,13 @@
 
 from abc import ABCMeta, abstractmethod, abstractproperty
 from pliers.transformers import Transformer
-from six import with_metaclass
 from pliers.utils import listify, EnvironmentKeyMixin
 from pliers import config
 import pliers
 import inspect
 
 
-class Converter(with_metaclass(ABCMeta, Transformer)):
+class Converter(Transformer, metaclass=ABCMeta):
 
     ''' Base class for Converters.'''
 

--- a/pliers/converters/base.py
+++ b/pliers/converters/base.py
@@ -1,11 +1,12 @@
 ''' Base Converter class and utilities. '''
 
 from abc import ABCMeta, abstractmethod, abstractproperty
+import inspect
+
 from pliers.transformers import Transformer
 from pliers.utils import listify, EnvironmentKeyMixin
 from pliers import config
 import pliers
-import inspect
 
 
 class Converter(Transformer, metaclass=ABCMeta):

--- a/pliers/converters/image.py
+++ b/pliers/converters/image.py
@@ -1,10 +1,11 @@
 ''' Converter classes that operate on ImageStim inputs. '''
 
 from PIL import Image
-from .base import Converter
+
 from pliers.stimuli.image import ImageStim
 from pliers.stimuli.text import TextStim
 from pliers.utils import attempt_to_import, verify_dependencies
+from .base import Converter
 
 pytesseract = attempt_to_import('pytesseract')
 

--- a/pliers/external/tensorflow/classify_image.py
+++ b/pliers/external/tensorflow/classify_image.py
@@ -42,7 +42,7 @@ import sys
 import tarfile
 
 import numpy as np
-from six.moves import urllib
+import urllib
 import tensorflow as tf
 
 FLAGS = None

--- a/pliers/extractors/api/clarifai.py
+++ b/pliers/extractors/api/clarifai.py
@@ -4,10 +4,7 @@ Extractors that interact with the Clarifai API.
 
 import logging
 import os
-try:
-    from contextlib import ExitStack
-except Exception as e:
-    from contextlib2 import ExitStack
+from contextlib import ExitStack
 from pliers.extractors.image import ImageExtractor
 from pliers.extractors.video import VideoExtractor
 from pliers.extractors.base import ExtractorResult

--- a/pliers/extractors/api/clarifai.py
+++ b/pliers/extractors/api/clarifai.py
@@ -5,13 +5,16 @@ Extractors that interact with the Clarifai API.
 import logging
 import os
 from contextlib import ExitStack
+
+import pandas as pd
+
 from pliers.extractors.image import ImageExtractor
 from pliers.extractors.video import VideoExtractor
 from pliers.extractors.base import ExtractorResult
 from pliers.transformers import BatchTransformerMixin
 from pliers.transformers.api import APITransformer
 from pliers.utils import listify, attempt_to_import, verify_dependencies
-import pandas as pd
+
 
 clarifai_client = attempt_to_import('clarifai.rest.client', 'clarifai_client',
                                     ['ClarifaiApp',

--- a/pliers/extractors/api/clarifai.py
+++ b/pliers/extractors/api/clarifai.py
@@ -66,7 +66,7 @@ class ClarifaiAPIExtractor(APITransformer):
             self.api = clarifai_client.ClarifaiApp(api_key=api_key)
             self.model = self.api.models.get(model)
         except clarifai_client.ApiError as e:
-            logging.warn(str(e))
+            logging.warning(str(e))
             self.api = None
             self.model = None
         self.model_name = model

--- a/pliers/extractors/api/google.py
+++ b/pliers/extractors/api/google.py
@@ -1,5 +1,14 @@
 ''' Google API-based feature extraction classes. '''
 
+import logging
+import time
+import warnings
+import os
+from collections import defaultdict
+
+import numpy as np
+import pandas as pd
+
 from pliers.extractors.image import ImageExtractor
 from pliers.extractors.text import TextExtractor
 from pliers.extractors.video import VideoExtractor
@@ -8,13 +17,6 @@ from pliers.transformers import (GoogleAPITransformer,
                                  GoogleAPITransformer)
 from pliers.extractors.base import ExtractorResult
 from pliers.utils import flatten_dict
-import numpy as np
-import pandas as pd
-import logging
-import time
-import warnings
-import os
-from collections import defaultdict
 
 
 class GoogleVisionAPIExtractor(GoogleVisionAPITransformer, ImageExtractor):

--- a/pliers/extractors/api/microsoft.py
+++ b/pliers/extractors/api/microsoft.py
@@ -2,12 +2,12 @@
 Extractors that interact with Microsoft Azure Cognitive Services API.
 '''
 
+import pandas as pd
+
 from pliers.extractors.base import ExtractorResult
 from pliers.extractors.image import ImageExtractor
 from pliers.transformers import (MicrosoftAPITransformer,
                                  MicrosoftVisionAPITransformer)
-
-import pandas as pd
 
 
 class MicrosoftAPIFaceExtractor(MicrosoftAPITransformer, ImageExtractor):

--- a/pliers/extractors/audio.py
+++ b/pliers/extractors/audio.py
@@ -1,18 +1,21 @@
 ''' Extractors that operate on AudioStim inputs. '''
+
+from abc import ABCMeta
+from os import path
+import sys
+import logging
+
+import numpy as np
+from scipy import fft
+import pandas as pd
+import soundfile as sf
+
 from pliers.stimuli.audio import AudioStim
 from pliers.stimuli.text import ComplexTextStim
 from pliers.extractors.base import Extractor, ExtractorResult
 from pliers.utils import attempt_to_import, verify_dependencies, listify
 from pliers.support.exceptions import MissingDependencyError
 from pliers.support.setup_yamnet import YAMNET_PATH
-import numpy as np
-from scipy import fft
-import pandas as pd
-import soundfile as sf
-from abc import ABCMeta
-from os import path
-import sys
-import logging
 
 librosa = attempt_to_import('librosa')
 tf = attempt_to_import('tensorflow')

--- a/pliers/extractors/base.py
+++ b/pliers/extractors/base.py
@@ -1,7 +1,6 @@
 ''' Base Extractor class and associated functionality. '''
 
 from abc import ABCMeta, abstractmethod
-from six import with_metaclass
 import pandas as pd
 import numpy as np
 from pliers.transformers import Transformer
@@ -10,7 +9,7 @@ from pandas.api.types import is_numeric_dtype
 import json
 
 
-class Extractor(with_metaclass(ABCMeta, Transformer)):
+class Extractor(Transformer, metaclass=ABCMeta):
 
     ''' Base class for all pliers Extractors.'''
 

--- a/pliers/extractors/base.py
+++ b/pliers/extractors/base.py
@@ -1,12 +1,14 @@
 ''' Base Extractor class and associated functionality. '''
 
 from abc import ABCMeta, abstractmethod
+import json
+
 import pandas as pd
 import numpy as np
+from pandas.api.types import is_numeric_dtype
+
 from pliers.transformers import Transformer
 from pliers.utils import isgenerator, flatten, listify
-from pandas.api.types import is_numeric_dtype
-import json
 
 
 class Extractor(Transformer, metaclass=ABCMeta):

--- a/pliers/extractors/image.py
+++ b/pliers/extractors/image.py
@@ -2,14 +2,15 @@
 Extractors that operate primarily or exclusively on Image stimuli.
 '''
 
+from functools import partial
+
+import numpy as np
+import pandas as pd
+
 from pliers.stimuli.image import ImageStim
 from pliers.extractors.base import Extractor, ExtractorResult
 from pliers.utils import attempt_to_import, verify_dependencies, listify
 from pliers.support.due import due, Url, Doi
-import numpy as np
-import pandas as pd
-from functools import partial
-
 
 cv2 = attempt_to_import('cv2')
 face_recognition = attempt_to_import('face_recognition')

--- a/pliers/extractors/models.py
+++ b/pliers/extractors/models.py
@@ -1,11 +1,11 @@
 ''' Extractor classes based on pre-trained models. '''
 
 import numpy as np
+
 from pliers.extractors.image import ImageExtractor
 from pliers.extractors.base import ExtractorResult
 from pliers.filters.image import ImageResizingFilter
 from pliers.utils import attempt_to_import, verify_dependencies
-
 
 tf = attempt_to_import('tensorflow')
 attempt_to_import('tensorflow.keras')

--- a/pliers/extractors/text.py
+++ b/pliers/extractors/text.py
@@ -2,6 +2,15 @@
 Extractors that operate primarily or exclusively on Text stimuli.
 '''
 import sys
+import itertools
+import logging
+
+import numpy as np
+import pandas as pd
+import scipy
+import nltk
+from nltk.sentiment.vader import SentimentIntensityAnalyzer
+
 from pliers.stimuli.text import TextStim, ComplexTextStim
 from pliers.extractors.base import Extractor, ExtractorResult
 from pliers.support.exceptions import PliersError
@@ -10,13 +19,6 @@ from pliers.datasets.text import fetch_dictionary
 from pliers.transformers import BatchTransformerMixin
 from pliers.utils import (attempt_to_import, verify_dependencies, flatten,
     listify)
-import itertools
-import numpy as np
-import pandas as pd
-import scipy
-import nltk
-from nltk.sentiment.vader import SentimentIntensityAnalyzer
-import logging
 
 
 keyedvectors = attempt_to_import('gensim.models.keyedvectors', 'keyedvectors',

--- a/pliers/extractors/text.py
+++ b/pliers/extractors/text.py
@@ -17,7 +17,7 @@ import scipy
 import nltk
 from nltk.sentiment.vader import SentimentIntensityAnalyzer
 import logging
-from six import string_types
+
 
 keyedvectors = attempt_to_import('gensim.models.keyedvectors', 'keyedvectors',
                                  ['KeyedVectors'])
@@ -68,7 +68,7 @@ class DictionaryExtractor(TextExtractor):
     VERSION = '1.0'
 
     def __init__(self, dictionary, variables=None, missing=np.nan):
-        if isinstance(dictionary, string_types):
+        if isinstance(dictionary, str):
             self.dictionary = dictionary  # for TranformationHistory logging
             dictionary = pd.read_csv(dictionary, sep='\t', index_col=0)
         else:

--- a/pliers/extractors/video.py
+++ b/pliers/extractors/video.py
@@ -2,11 +2,11 @@
 Extractors that operate primarily or exclusively on Video stimuli.
 '''
 
+import numpy as np
+
 from pliers.stimuli.video import VideoStim
 from pliers.extractors.base import Extractor, ExtractorResult
 from pliers.utils import attempt_to_import, verify_dependencies
-
-import numpy as np
 
 cv2 = attempt_to_import('cv2')
 

--- a/pliers/filters/audio.py
+++ b/pliers/filters/audio.py
@@ -1,9 +1,10 @@
 ''' Filters that operate on TextStim inputs. '''
 
+from copy import deepcopy
+
 from pliers.stimuli import AudioStim
 from pliers.utils import attempt_to_import, verify_dependencies
 from .base import Filter, TemporalTrimmingFilter
-from copy import deepcopy
 
 librosa = attempt_to_import('librosa')
 

--- a/pliers/filters/base.py
+++ b/pliers/filters/base.py
@@ -1,7 +1,6 @@
 ''' Base Filter class and associated functionality. '''
 
 from abc import ABCMeta, abstractmethod
-from six import with_metaclass
 from pliers.stimuli import AudioStim, VideoStim
 from pliers.transformers import Transformer
 from pliers.utils import listify
@@ -9,7 +8,7 @@ from pliers.utils import listify
 import logging
 
 
-class Filter(with_metaclass(ABCMeta, Transformer)):
+class Filter(Transformer, metaclass=ABCMeta):
     ''' Base class for Filters.'''
 
     def _transform(self, stim, *args, **kwargs):

--- a/pliers/filters/base.py
+++ b/pliers/filters/base.py
@@ -59,7 +59,7 @@ class TemporalTrimmingFilter(Filter):
         end = self.end / getattr(stim, rate) if self.frames else self.end
         if end and end > stim.duration:
             if self.validation == 'warn':
-                logging.warn("Attempted to trim beyond the duration of the"
+                logging.warning("Attempted to trim beyond the duration of the"
                              "clip, instead trimming to the end of the clip")
                 end = stim.duration
             else:

--- a/pliers/filters/base.py
+++ b/pliers/filters/base.py
@@ -1,11 +1,11 @@
 ''' Base Filter class and associated functionality. '''
 
 from abc import ABCMeta, abstractmethod
+import logging
+
 from pliers.stimuli import AudioStim, VideoStim
 from pliers.transformers import Transformer
 from pliers.utils import listify
-
-import logging
 
 
 class Filter(Transformer, metaclass=ABCMeta):

--- a/pliers/filters/image.py
+++ b/pliers/filters/image.py
@@ -1,11 +1,11 @@
 ''' Filters that operate on ImageStim inputs. '''
 
-from pliers.stimuli.image import ImageStim
+import numpy as np
 from PIL import Image
 from PIL import ImageFilter as PillowFilter
-from .base import Filter
 
-import numpy as np
+from pliers.stimuli.image import ImageStim
+from .base import Filter
 
 
 class ImageFilter(Filter):

--- a/pliers/filters/text.py
+++ b/pliers/filters/text.py
@@ -4,7 +4,6 @@ import nltk
 import string
 import re
 
-from six import string_types
 from nltk import stem
 from nltk.tokenize import word_tokenize
 from nltk.tokenize import * # noqa
@@ -55,7 +54,7 @@ class WordStemmingFilter(TextFilter):
     @requires_nltk_corpus
     def __init__(self, stemmer='porter', tokenize=True, case_sensitive=False,
                  *args, **kwargs):
-        if isinstance(stemmer, string_types):
+        if isinstance(stemmer, str):
             if stemmer not in self._stemmers:
                 valid = list(self._stemmers.keys())
                 raise ValueError("Invalid stemmer '%s'; please use one of %s."

--- a/pliers/filters/text.py
+++ b/pliers/filters/text.py
@@ -1,13 +1,14 @@
 ''' Filters that operate on TextStim inputs. '''
 
-import nltk
 import string
 import re
 
+import nltk
 from nltk import stem
 from nltk.tokenize import word_tokenize
 from nltk.tokenize import * # noqa
 from nltk.tokenize.api import TokenizerI
+
 from pliers.stimuli.text import TextStim
 from pliers.support.decorators import requires_nltk_corpus
 from .base import Filter

--- a/pliers/filters/video.py
+++ b/pliers/filters/video.py
@@ -1,11 +1,10 @@
 ''' Filters that operate on TextStim inputs. '''
 
+import numpy as np
+
 from pliers.stimuli.video import VideoStim, VideoFrameCollectionStim
 from pliers.utils import attempt_to_import, verify_dependencies
 from .base import Filter, TemporalTrimmingFilter
-
-import numpy as np
-
 
 cv2 = attempt_to_import('cv2')
 

--- a/pliers/graph.py
+++ b/pliers/graph.py
@@ -7,7 +7,6 @@ from pliers.transformers import get_transformer
 from pliers.utils import (listify, flatten, isgenerator, attempt_to_import,
                           verify_dependencies)
 from itertools import chain
-from six import string_types
 from collections import OrderedDict
 
 import json
@@ -30,7 +29,7 @@ class Node(object):
     def __init__(self, transformer, name=None, **parameters):
         self.name = name
         self.children = []
-        if isinstance(transformer, string_types):
+        if isinstance(transformer, str):
             transformer = get_transformer(transformer, **parameters)
         self.transformer = transformer
         self.parameters = parameters
@@ -220,7 +219,7 @@ class Graph(object):
             stim (str, stim, list): Any valid input to the Transformer stored
                 at the target node.
         '''
-        if isinstance(node, string_types):
+        if isinstance(node, str):
             node = self.nodes[node]
 
         result = node.transformer.transform(stim)

--- a/pliers/graph.py
+++ b/pliers/graph.py
@@ -1,15 +1,14 @@
 ''' The `graph` module contains tools for constructing and executing graphs
 of pliers Transformers. '''
+from itertools import chain
+from collections import OrderedDict
+import json
 
 from pliers.extractors.base import merge_results
 from pliers.stimuli import __all__ as stim_list
 from pliers.transformers import get_transformer
 from pliers.utils import (listify, flatten, isgenerator, attempt_to_import,
                           verify_dependencies)
-from itertools import chain
-from collections import OrderedDict
-
-import json
 
 pgv = attempt_to_import('pygraphviz', 'pgv')
 stim_list.insert(0, 'ExtractorResult')

--- a/pliers/stimuli/api.py
+++ b/pliers/stimuli/api.py
@@ -72,7 +72,7 @@ class TweetStimFactory(APIDependent):
             self.api.VerifyCredentials()
             return True
         except twitter.error.TwitterError as e:
-            logging.warn(str(e))
+            logging.warning(str(e))
             return False
 
     def get_status(self, status_id):

--- a/pliers/stimuli/audio.py
+++ b/pliers/stimuli/audio.py
@@ -1,8 +1,9 @@
 ''' Classes that represent audio clips. '''
 
-from .base import Stim
 from moviepy.audio.io.AudioFileClip import AudioFileClip
 from moviepy.video.io.ffmpeg_reader import ffmpeg_parse_infos
+
+from .base import Stim
 
 
 class AudioStim(Stim):

--- a/pliers/stimuli/base.py
+++ b/pliers/stimuli/base.py
@@ -4,7 +4,7 @@
 from abc import ABCMeta, abstractmethod
 from os.path import isdir, join, basename, realpath, isfile
 from glob import glob
-from six import with_metaclass, string_types
+from six import with_metaclass, str
 from six.moves.urllib.request import urlopen
 from six.moves.urllib.parse import urlparse
 from collections import namedtuple
@@ -114,7 +114,7 @@ def load_stims(source, dtype=None, fail_silently=False):
     from .audio import AudioStim
     from .text import TextStim
 
-    if isinstance(source, string_types):
+    if isinstance(source, str):
         return_list = False
         source = [source]
     else:
@@ -133,7 +133,7 @@ def load_stims(source, dtype=None, fail_silently=False):
         source = realpath(source)
         import magic  # requires libmagic, so import here
         mime = magic.from_file(source, mime=True)
-        if not isinstance(mime, string_types):
+        if not isinstance(mime, str):
             mime = mime.decode('utf-8')
         mime = mime.split('/')[0]
         if mime in stim_map.keys():

--- a/pliers/stimuli/base.py
+++ b/pliers/stimuli/base.py
@@ -4,7 +4,6 @@
 from abc import ABCMeta, abstractmethod
 from os.path import isdir, join, basename, realpath, isfile
 from glob import glob
-from six import with_metaclass, str
 from six.moves.urllib.request import urlopen
 from six.moves.urllib.parse import urlparse
 from collections import namedtuple
@@ -17,7 +16,7 @@ import tempfile
 import base64
 
 
-class Stim(with_metaclass(ABCMeta)):
+class Stim(metaclass=ABCMeta):
 
     ''' Base class for all classes in the Stim hierarchy.
 

--- a/pliers/stimuli/base.py
+++ b/pliers/stimuli/base.py
@@ -1,6 +1,5 @@
 ''' Base class for all Stims and associated functionality. '''
 
-
 from abc import ABCMeta, abstractmethod
 from os.path import isdir, join, basename, realpath, isfile
 from glob import glob
@@ -8,12 +7,14 @@ from urllib.request import urlopen
 from urllib.parse import urlparse
 from collections import namedtuple
 from contextlib import contextmanager
-from pliers import config
-from pliers.utils import isiterable
-import pandas as pd
 import os
 import tempfile
 import base64
+
+import pandas as pd
+
+from pliers import config
+from pliers.utils import isiterable
 
 
 class Stim(metaclass=ABCMeta):

--- a/pliers/stimuli/base.py
+++ b/pliers/stimuli/base.py
@@ -4,8 +4,8 @@
 from abc import ABCMeta, abstractmethod
 from os.path import isdir, join, basename, realpath, isfile
 from glob import glob
-from six.moves.urllib.request import urlopen
-from six.moves.urllib.parse import urlparse
+from urllib.request import urlopen
+from urllib.parse import urlparse
 from collections import namedtuple
 from contextlib import contextmanager
 from pliers import config

--- a/pliers/stimuli/compound.py
+++ b/pliers/stimuli/compound.py
@@ -1,7 +1,6 @@
 ''' A CompoundStim class represents a combination of constituent Stim classes.
 '''
 
-from six import string_types
 from pliers.utils import listify
 from .base import _get_stim_class
 from .audio import AudioStim
@@ -68,7 +67,7 @@ class CompoundStim(object):
             list if no elements match). If return_all is False, returns the
             first matching Stim, or None if no elements match.
         '''
-        if isinstance(type_, string_types):
+        if isinstance(type_, str):
             type_ = _get_stim_class(type_)
         matches = []
         for s in self.elements:

--- a/pliers/stimuli/image.py
+++ b/pliers/stimuli/image.py
@@ -1,13 +1,15 @@
 ''' Classes that represent images. '''
 
-from .base import Stim
-from imageio import imread, imsave
-from PIL import Image
+from functools import lru_cache
 from urllib.request import urlopen
 import io
+
+from imageio import imread, imsave
+from PIL import Image
 import numpy as np
-from functools import lru_cache
+
 from .base import _get_bytestring
+from .base import Stim
 
 
 class ImageStim(Stim):

--- a/pliers/stimuli/text.py
+++ b/pliers/stimuli/text.py
@@ -2,7 +2,7 @@
 
 import re
 import pandas as pd
-from six.moves.urllib.request import urlopen
+from urllib.request import urlopen
 from pliers.support.decorators import requires_nltk_corpus
 from pliers.utils import attempt_to_import, verify_dependencies
 from .base import Stim

--- a/pliers/stimuli/text.py
+++ b/pliers/stimuli/text.py
@@ -1,8 +1,10 @@
 ''' Classes that represent text or sequences of text. '''
 
 import re
-import pandas as pd
 from urllib.request import urlopen
+
+import pandas as pd
+
 from pliers.support.decorators import requires_nltk_corpus
 from pliers.utils import attempt_to_import, verify_dependencies
 from .base import Stim

--- a/pliers/stimuli/text.py
+++ b/pliers/stimuli/text.py
@@ -2,7 +2,6 @@
 
 import re
 import pandas as pd
-from six import string_types
 from six.moves.urllib.request import urlopen
 from pliers.support.decorators import requires_nltk_corpus
 from pliers.utils import attempt_to_import, verify_dependencies
@@ -219,7 +218,7 @@ class ComplexTextStim(Stim):
     def _from_text(self, text, unit, tokenizer, language):
 
         if tokenizer is not None:
-            if isinstance(tokenizer, string_types):
+            if isinstance(tokenizer, str):
                 tokens = re.findall(tokenizer, text)
             else:
                 tokens = tokenizer.tokenize(text)

--- a/pliers/stimuli/video.py
+++ b/pliers/stimuli/video.py
@@ -2,7 +2,9 @@
 
 from __future__ import division
 from math import ceil
+
 from moviepy.video.io.VideoFileClip import VideoFileClip
+
 from .base import Stim, _get_bytestring
 from .audio import AudioStim
 from .image import ImageStim

--- a/pliers/support/decorators.py
+++ b/pliers/support/decorators.py
@@ -2,6 +2,7 @@
 """Custom decorators."""
 from __future__ import absolute_import
 from functools import wraps
+
 from pliers.support.exceptions import MissingCorpusError
 
 

--- a/pliers/tests/converters/api/test_google_converters.py
+++ b/pliers/tests/converters/api/test_google_converters.py
@@ -1,9 +1,11 @@
 from os.path import join
+
+import pytest
+
 from ...utils import get_test_data_path
 from pliers.converters import (GoogleVisionAPITextConverter,
                                GoogleSpeechAPIConverter)
 from pliers.stimuli import ImageStim, AudioStim, ComplexTextStim
-import pytest
 
 IMAGE_DIR = join(get_test_data_path(), 'image')
 AUDIO_DIR = join(get_test_data_path(), 'audio')

--- a/pliers/tests/converters/api/test_ibm_converters.py
+++ b/pliers/tests/converters/api/test_ibm_converters.py
@@ -1,9 +1,11 @@
 from os.path import join
+
+import pytest
+
 from ...utils import get_test_data_path
 from pliers import config
 from pliers.converters import IBMSpeechAPIConverter
 from pliers.stimuli import AudioStim, TextStim, ComplexTextStim
-import pytest
 
 AUDIO_DIR = join(get_test_data_path(), 'audio')
 

--- a/pliers/tests/converters/api/test_microsoft_converters.py
+++ b/pliers/tests/converters/api/test_microsoft_converters.py
@@ -1,8 +1,10 @@
 from os.path import join
+
+import pytest
+
 from ...utils import get_test_data_path
 from pliers.converters import MicrosoftAPITextConverter
 from pliers.stimuli import ImageStim
-import pytest
 
 IMAGE_DIR = join(get_test_data_path(), 'image')
 

--- a/pliers/tests/converters/api/test_revai_converters.py
+++ b/pliers/tests/converters/api/test_revai_converters.py
@@ -1,8 +1,10 @@
 from os.path import join
+
+import pytest
+
 from ...utils import get_test_data_path
 from pliers.converters import RevAISpeechAPIConverter
 from pliers.stimuli import AudioStim, ComplexTextStim, TextStim
-import pytest
 
 AUDIO_DIR = join(get_test_data_path(), 'audio')
 

--- a/pliers/tests/converters/api/test_wit_converters.py
+++ b/pliers/tests/converters/api/test_wit_converters.py
@@ -1,8 +1,10 @@
 from os.path import join
+
+import pytest
+
 from ...utils import get_test_data_path
 from pliers.converters import WitTranscriptionConverter
 from pliers.stimuli import AudioStim, TextStim, ComplexTextStim
-import pytest
 
 AUDIO_DIR = join(get_test_data_path(), 'audio')
 

--- a/pliers/tests/converters/test_converters.py
+++ b/pliers/tests/converters/test_converters.py
@@ -1,4 +1,7 @@
 from os.path import join
+
+import pytest
+
 from ..utils import get_test_data_path
 from pliers.converters import (get_converter,
                                VideoToAudioConverter,
@@ -8,7 +11,6 @@ from pliers.converters import (get_converter,
 from pliers.converters.image import ImageToTextConverter
 from pliers.stimuli import (VideoStim, TextStim,
                             ComplexTextStim, ImageStim)
-import pytest
 
 
 def test_get_converter():

--- a/pliers/tests/converters/test_image_converters.py
+++ b/pliers/tests/converters/test_image_converters.py
@@ -1,8 +1,10 @@
 from os.path import join
+
+import pytest
+
 from ..utils import get_test_data_path
 from pliers.converters import TesseractConverter
 from pliers.stimuli import ImageStim
-import pytest
 
 IMAGE_DIR = join(get_test_data_path(), 'image')
 

--- a/pliers/tests/converters/test_video_converters.py
+++ b/pliers/tests/converters/test_video_converters.py
@@ -1,8 +1,10 @@
 from os.path import join
+
+import numpy as np
+
 from ..utils import get_test_data_path
 from pliers.converters import VideoToAudioConverter
 from pliers.stimuli import VideoStim
-import numpy as np
 
 VIDEO_DIR = join(get_test_data_path(), 'video')
 

--- a/pliers/tests/extractors/api/test_clarifai_extractors.py
+++ b/pliers/tests/extractors/api/test_clarifai_extractors.py
@@ -1,12 +1,14 @@
 from os.path import join
+
+import numpy as np
+import pytest
+
 from ...utils import get_test_data_path
 from pliers import config
 from pliers.extractors import (ClarifaiAPIImageExtractor,
                                ClarifaiAPIVideoExtractor)
 from pliers.extractors.base import merge_results
 from pliers.stimuli import ImageStim, VideoStim
-import numpy as np
-import pytest
 
 IMAGE_DIR = join(get_test_data_path(), 'image')
 VIDEO_DIR = join(get_test_data_path(), 'video')

--- a/pliers/tests/extractors/api/test_google_extractors.py
+++ b/pliers/tests/extractors/api/test_google_extractors.py
@@ -1,3 +1,9 @@
+import json
+from os.path import join
+
+import pytest
+import numpy as np
+
 from pliers import config
 from pliers.filters import FrameSamplingFilter
 from pliers.extractors import (GoogleVisionAPIFaceExtractor,
@@ -20,11 +26,8 @@ from pliers.extractors import (GoogleVisionAPIFaceExtractor,
 from pliers.extractors.api.google import GoogleVisionAPIExtractor
 from pliers.stimuli import ImageStim, VideoStim, TextStim
 from pliers.utils import attempt_to_import, verify_dependencies
-import pytest
-import json
-from os.path import join
 from ...utils import get_test_data_path
-import numpy as np
+
 
 googleapiclient = attempt_to_import('googleapiclient', fromlist=['discovery'])
 

--- a/pliers/tests/extractors/api/test_microsoft_extractors.py
+++ b/pliers/tests/extractors/api/test_microsoft_extractors.py
@@ -1,3 +1,7 @@
+from os.path import join
+
+import pytest
+
 from pliers import config
 from pliers.extractors import (MicrosoftAPIFaceExtractor,
                                MicrosoftAPIFaceEmotionExtractor,
@@ -9,8 +13,6 @@ from pliers.extractors import (MicrosoftAPIFaceExtractor,
                                MicrosoftVisionAPIAdultExtractor)
 from pliers.extractors import merge_results
 from pliers.stimuli import ImageStim, VideoStim
-import pytest
-from os.path import join
 from ...utils import get_test_data_path
 
 IMAGE_DIR = join(get_test_data_path(), 'image')

--- a/pliers/tests/extractors/test_audio_extractors.py
+++ b/pliers/tests/extractors/test_audio_extractors.py
@@ -1,5 +1,9 @@
 from os.path import join
 from os import environ
+
+import numpy as np
+import pytest
+
 from ..utils import get_test_data_path
 from pliers.extractors import (LibrosaFeatureExtractor,
                                STFTAudioExtractor,
@@ -30,8 +34,7 @@ from pliers.stimuli import (ComplexTextStim, AudioStim,
                             TranscribedAudioCompoundStim)
 from pliers.filters import AudioResamplingFilter
 from pliers.utils import attempt_to_import, verify_dependencies
-import numpy as np
-import pytest
+
 
 AUDIO_DIR = join(get_test_data_path(), 'audio')
 tf = attempt_to_import('tensorflow')

--- a/pliers/tests/extractors/test_extractors.py
+++ b/pliers/tests/extractors/test_extractors.py
@@ -1,4 +1,9 @@
 from os.path import join
+import json
+
+import numpy as np
+import pytest
+
 from pliers.tests.utils import (get_test_data_path, DummyExtractor, 
                                 ClashingFeatureExtractor)
 from pliers.extractors import (LengthExtractor,
@@ -10,9 +15,6 @@ from pliers.stimuli import (ComplexTextStim, ImageStim, VideoStim,
 from pliers.support.download import download_nltk_data
 from pliers.extractors.base import ExtractorResult, merge_results
 from pliers import config
-import numpy as np
-import pytest
-import json
 
 TEXT_DIR = join(get_test_data_path(), 'text')
 

--- a/pliers/tests/extractors/test_image_extractors.py
+++ b/pliers/tests/extractors/test_image_extractors.py
@@ -1,4 +1,8 @@
 from os.path import join
+
+import numpy as np
+import pytest
+
 from ..utils import get_test_data_path
 from pliers.extractors import (BrightnessExtractor,
                                SharpnessExtractor,
@@ -10,8 +14,7 @@ from pliers.extractors import (BrightnessExtractor,
                                FaceRecognitionFaceEncodingsExtractor)
 from pliers.stimuli import ImageStim
 from pliers.extractors.base import merge_results
-import numpy as np
-import pytest
+
 
 IMAGE_DIR = join(get_test_data_path(), 'image')
 

--- a/pliers/tests/extractors/test_text_extractors.py
+++ b/pliers/tests/extractors/test_text_extractors.py
@@ -1,3 +1,14 @@
+
+from os.path import join
+from pathlib import Path
+from os import environ
+import shutil
+
+import numpy as np
+import pytest
+import spacy
+from transformers import BertTokenizer
+
 from pliers import config
 from pliers.extractors import (DictionaryExtractor,
                                PartOfSpeechExtractor,
@@ -16,14 +27,7 @@ from pliers.extractors import (DictionaryExtractor,
 from pliers.extractors.base import merge_results
 from pliers.stimuli import TextStim, ComplexTextStim
 from pliers.tests.utils import get_test_data_path
-import numpy as np
-from os.path import join
-from pathlib import Path
-import shutil
-import pytest
-import spacy
-from os import environ
-from transformers import BertTokenizer
+
 
 TEXT_DIR = join(get_test_data_path(), 'text')
 

--- a/pliers/tests/extractors/test_video_extractors.py
+++ b/pliers/tests/extractors/test_video_extractors.py
@@ -1,9 +1,11 @@
 from os.path import join
+
+import numpy as np
+import pytest
+
 from ..utils import get_test_data_path
 from pliers.extractors import FarnebackOpticalFlowExtractor
 from pliers.stimuli import VideoStim
-import numpy as np
-import pytest
 
 VIDEO_DIR = join(get_test_data_path(), 'video')
 

--- a/pliers/tests/filters/test_audio_filters.py
+++ b/pliers/tests/filters/test_audio_filters.py
@@ -1,11 +1,13 @@
 from os.path import join
+
+import pytest
+import numpy as np
+
 from ..utils import get_test_data_path
 from pliers.filters import (AudioTrimmingFilter, 
                             TemporalTrimmingFilter,
                             AudioResamplingFilter)
 from pliers.stimuli import AudioStim
-import pytest
-import numpy as np
 
 AUDIO_DIR = join(get_test_data_path(), 'audio')
 

--- a/pliers/tests/filters/test_image_filters.py
+++ b/pliers/tests/filters/test_image_filters.py
@@ -1,11 +1,13 @@
 from os.path import join
+
+import numpy as np
+import pytest
+
 from ..utils import get_test_data_path
 from pliers.filters import (ImageCroppingFilter,
                             ImageResizingFilter,
                             PillowImageFilter)
 from pliers.stimuli import ImageStim
-import numpy as np
-import pytest
 
 IMAGE_DIR = join(get_test_data_path(), 'image')
 

--- a/pliers/tests/filters/test_text_filters.py
+++ b/pliers/tests/filters/test_text_filters.py
@@ -1,4 +1,11 @@
 from os.path import join
+import string
+
+from nltk import stem as nls
+from nltk.tokenize import PunktSentenceTokenizer
+import nltk
+import pytest
+
 from ..utils import get_test_data_path
 from pliers.filters import (WordStemmingFilter,
                             TokenizingFilter,
@@ -7,11 +14,6 @@ from pliers.filters import (WordStemmingFilter,
                             PunctuationRemovalFilter)
 from pliers.graph import Graph
 from pliers.stimuli import ComplexTextStim, TextStim
-from nltk import stem as nls
-from nltk.tokenize import PunktSentenceTokenizer
-import nltk
-import pytest
-import string
 
 
 TEXT_DIR = join(get_test_data_path(), 'text')

--- a/pliers/tests/filters/test_video_filters.py
+++ b/pliers/tests/filters/test_video_filters.py
@@ -1,11 +1,14 @@
 from os.path import join
+import math
+
+import pytest
+
 from ..utils import get_test_data_path
 from pliers.filters import (FrameSamplingFilter,
                             VideoTrimmingFilter,
                             TemporalTrimmingFilter)
 from pliers.stimuli import VideoStim, VideoFrameStim
-import pytest
-import math
+
 
 VIDEO_DIR = join(get_test_data_path(), 'video')
 

--- a/pliers/tests/test_config.py
+++ b/pliers/tests/test_config.py
@@ -1,8 +1,10 @@
-import pliers
 import tempfile
 import os
 import json
+
 import pytest
+
+import pliers
 from pliers.config import reset_options
 
 

--- a/pliers/tests/test_datasets.py
+++ b/pliers/tests/test_datasets.py
@@ -1,5 +1,6 @@
-from pliers.datasets.text import _load_datasets
 import requests
+
+from pliers.datasets.text import _load_datasets
 
 
 def test_dicts_exist_at_url_and_initialize():

--- a/pliers/tests/test_diagnostics.py
+++ b/pliers/tests/test_diagnostics.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import numpy as np
+
 from pliers.diagnostics import Diagnostics
 from pliers.diagnostics import correlation_matrix
 from pliers.diagnostics import eigenvalues

--- a/pliers/tests/test_graph.py
+++ b/pliers/tests/test_graph.py
@@ -1,4 +1,11 @@
+from os.path import join, exists
+import tempfile
+import os
+
+from numpy.testing import assert_almost_equal
+import pandas as pd
 import pytest
+
 from pliers.graph import Graph, Node
 from pliers.converters import (TesseractConverter,
                                VideoToAudioConverter,
@@ -8,11 +15,6 @@ from pliers.extractors import (BrightnessExtractor, VibranceExtractor,
                                LengthExtractor, merge_results)
 from pliers.stimuli import (ImageStim, TextStim, VideoStim)
 from .utils import get_test_data_path, DummyExtractor
-from os.path import join, exists
-from numpy.testing import assert_almost_equal
-import pandas as pd
-import tempfile
-import os
 
 
 def test_node_init():

--- a/pliers/tests/test_io.py
+++ b/pliers/tests/test_io.py
@@ -1,7 +1,6 @@
 from .utils import get_test_data_path
 from pliers.stimuli import load_stims
 from os.path import join
-from six import string_types
 import pytest
 
 
@@ -13,7 +12,7 @@ def test_magic_loader():
     stims = load_stims(stim_files)
     assert len(stims) == 3
     assert round(stims[1].duration) == 57
-    assert isinstance(stims[0].text, string_types)
+    assert isinstance(stims[0].text, str)
     assert stims[2].width == 560
 
 

--- a/pliers/tests/test_io.py
+++ b/pliers/tests/test_io.py
@@ -1,8 +1,9 @@
-from .utils import get_test_data_path
-from pliers.stimuli import load_stims
 from os.path import join
+
 import pytest
 
+from .utils import get_test_data_path
+from pliers.stimuli import load_stims
 
 def test_magic_loader():
     text_file = join(get_test_data_path(), 'text', 'sample_text.txt')

--- a/pliers/tests/test_scikit.py
+++ b/pliers/tests/test_scikit.py
@@ -1,13 +1,14 @@
-from .utils import get_test_data_path
+from os.path import join
 
 import pytest
 import numpy as np
 
-from os.path import join
 from pliers.extractors import BrightnessExtractor, SharpnessExtractor
 from pliers.graph import Graph
 from pliers.utils.scikit import PliersTransformer
 from pliers.stimuli import ImageStim
+
+from .utils import get_test_data_path
 
 
 def test_graph_scikit():

--- a/pliers/tests/test_stims.py
+++ b/pliers/tests/test_stims.py
@@ -1,3 +1,12 @@
+import tempfile
+import os
+import base64
+from os.path import join, exists
+
+import numpy as np
+import pandas as pd
+import pytest
+
 from .utils import get_test_data_path
 from pliers.stimuli import (VideoStim, VideoFrameStim, ComplexTextStim,
                             AudioStim, ImageStim, CompoundStim,
@@ -10,13 +19,6 @@ from pliers.extractors import (BrightnessExtractor, LengthExtractor,
                                ComplexTextExtractor)
 from pliers.extractors.base import Extractor, ExtractorResult
 from pliers.support.download import download_nltk_data
-import numpy as np
-from os.path import join, exists
-import pandas as pd
-import pytest
-import tempfile
-import os
-import base64
 
 
 class DummyExtractor(Extractor):

--- a/pliers/tests/test_transformers.py
+++ b/pliers/tests/test_transformers.py
@@ -1,13 +1,16 @@
+from os.path import join
+
+import numpy as np
+import pytest
+
 from pliers.transformers import get_transformer
 from pliers.extractors import (STFTAudioExtractor, BrightnessExtractor,
                                merge_results)
 from pliers.stimuli.base import TransformationLog
 from pliers.stimuli import ImageStim, VideoStim, TextStim
 from pliers import config
-from os.path import join
+
 from .utils import get_test_data_path, DummyExtractor, DummyBatchExtractor
-import numpy as np
-import pytest
 
 
 def test_get_transformer_by_name():

--- a/pliers/tests/test_updater.py
+++ b/pliers/tests/test_updater.py
@@ -1,6 +1,9 @@
-from pliers.utils.updater import check_updates
 from tempfile import NamedTemporaryFile
+
 import pandas as pd
+
+from pliers.utils.updater import check_updates
+
 
 def test_updater():
     datastore_file = NamedTemporaryFile().name

--- a/pliers/tests/test_utils.py
+++ b/pliers/tests/test_utils.py
@@ -1,11 +1,14 @@
+from types import GeneratorType
+from os.path import join
+
+import pytest
+
 from pliers.stimuli import VideoStim
 from pliers.filters import FrameSamplingFilter
 from pliers.utils import batch_iterable, flatten_dict
 from pliers import config
-from types import GeneratorType
+
 from .utils import get_test_data_path
-from os.path import join
-import pytest
 
 
 @pytest.mark.skip(reason="tqdm prevents normal stdout/stderr capture; need to"

--- a/pliers/tests/utils.py
+++ b/pliers/tests/utils.py
@@ -1,10 +1,13 @@
 from os.path import dirname, join
+from copy import deepcopy
+
+import numpy as np
+import pandas as pd
+
 from pliers.stimuli import ImageStim
 from pliers.extractors.base import Extractor, ExtractorResult
 from pliers.transformers import BatchTransformerMixin
-import numpy as np
-from copy import deepcopy
-import pandas as pd
+
 
 def get_test_data_path():
     """Returns the path to test datasets """

--- a/pliers/transformers/api/base.py
+++ b/pliers/transformers/api/base.py
@@ -1,9 +1,9 @@
 ''' Base implementation for all API transformers. '''
+import time
 
 from pliers import config
 from pliers.transformers import Transformer
 from pliers.utils import isiterable, listify, APIDependent
-import time
 
 
 class APITransformer(APIDependent, Transformer):

--- a/pliers/transformers/api/google.py
+++ b/pliers/transformers/api/google.py
@@ -1,5 +1,6 @@
 import logging
 import os
+
 from pliers.transformers import BatchTransformerMixin
 from pliers.transformers.api import APITransformer
 from pliers.utils import attempt_to_import, verify_dependencies

--- a/pliers/transformers/api/google.py
+++ b/pliers/transformers/api/google.py
@@ -49,7 +49,7 @@ class GoogleAPITransformer(APITransformer):
                 self.api_name, api_version, credentials=self.credentials,
                 discoveryServiceUrl=DISCOVERY_URL)
         except Exception as e:
-            logging.warn(str(e))
+            logging.warning(str(e))
             self.credentials = None
             self.service = None
         self.max_results = max_results

--- a/pliers/transformers/api/microsoft.py
+++ b/pliers/transformers/api/microsoft.py
@@ -69,10 +69,10 @@ class MicrosoftAPITransformer(APITransformer):
             if 'too small' in str(e):
                 return True
             elif 'invalid subscription' in str(e):
-                logging.warn(str(e))
+                logging.warning(str(e))
                 return False
             elif '[Errno 8]' in str(e):
-                logging.warn(str(e))
+                logging.warning(str(e))
                 return False
             else:
                 raise e

--- a/pliers/transformers/api/microsoft.py
+++ b/pliers/transformers/api/microsoft.py
@@ -1,6 +1,8 @@
 import logging
 import os
+
 import requests
+
 from pliers.transformers.api import APITransformer
 
 

--- a/pliers/transformers/base.py
+++ b/pliers/transformers/base.py
@@ -7,7 +7,7 @@ from pliers.utils import (progress_bar_wrapper, isiterable,
                           isgenerator, listify, batch_iterable,
                           attempt_to_import, set_iterable_type)
 import pliers
-from six import with_metaclass, string_types
+from six import with_metaclass, str
 from abc import ABCMeta, abstractmethod, abstractproperty
 import importlib
 import logging
@@ -48,7 +48,7 @@ class Transformer(with_metaclass(ABCMeta)):
         @wraps(transform)
         def wrapper(self, stim, *args, **kwargs):
             use_cache = config.get_option('cache_transformers') \
-                and isinstance(stim, (Stim, string_types))
+                and isinstance(stim, (Stim, str))
             if use_cache:
                 key = hash((hash(self), hash(stim)))
                 if key in _cache:
@@ -88,7 +88,7 @@ class Transformer(with_metaclass(ABCMeta)):
                 _transform call.
         '''
 
-        if isinstance(stims, string_types):
+        if isinstance(stims, str):
             stims = load_stims(stims)
 
         # If stims is a CompoundStim and the Transformer is expecting a single

--- a/pliers/transformers/base.py
+++ b/pliers/transformers/base.py
@@ -118,7 +118,7 @@ class Transformer(with_metaclass(ABCMeta)):
                 if validation == 'strict':
                     raise err
                 elif validation == 'warn':
-                    logging.warn(str(err))
+                    logging.warning(str(err))
                     return
                 elif validation == 'loose':
                     return

--- a/pliers/transformers/base.py
+++ b/pliers/transformers/base.py
@@ -1,4 +1,8 @@
 ''' Core transformer logic. '''
+from abc import ABCMeta, abstractmethod, abstractproperty
+import importlib
+import logging
+from functools import wraps
 
 from pliers import config
 from pliers.stimuli.base import Stim, _log_transformation, load_stims
@@ -7,10 +11,7 @@ from pliers.utils import (progress_bar_wrapper, isiterable,
                           isgenerator, listify, batch_iterable,
                           attempt_to_import, set_iterable_type)
 import pliers
-from abc import ABCMeta, abstractmethod, abstractproperty
-import importlib
-import logging
-from functools import wraps
+
 
 multiprocessing = attempt_to_import('pathos.multiprocessing',
                                     'multiprocessing', ['ProcessingPool'])

--- a/pliers/transformers/base.py
+++ b/pliers/transformers/base.py
@@ -7,7 +7,6 @@ from pliers.utils import (progress_bar_wrapper, isiterable,
                           isgenerator, listify, batch_iterable,
                           attempt_to_import, set_iterable_type)
 import pliers
-from six import with_metaclass, str
 from abc import ABCMeta, abstractmethod, abstractproperty
 import importlib
 import logging
@@ -19,7 +18,7 @@ multiprocessing = attempt_to_import('pathos.multiprocessing',
 _cache = {}
 
 
-class Transformer(with_metaclass(ABCMeta)):
+class Transformer(metaclass=ABCMeta):
     ''' Base class for all pliers Transformers.
 
     Args:

--- a/pliers/utils/base.py
+++ b/pliers/utils/base.py
@@ -3,11 +3,13 @@
 import collections
 import os
 from abc import ABCMeta, abstractmethod, abstractproperty
-from tqdm import tqdm
-from pliers import config
-from pliers.support.exceptions import MissingDependencyError
 from types import GeneratorType
 from itertools import islice
+
+from tqdm import tqdm
+
+from pliers import config
+from pliers.support.exceptions import MissingDependencyError
 
 
 def listify(obj):

--- a/pliers/utils/base.py
+++ b/pliers/utils/base.py
@@ -3,7 +3,7 @@
 import collections
 import os
 from abc import ABCMeta, abstractmethod, abstractproperty
-from six import string_types, with_metaclass
+from six with_metaclass
 from tqdm import tqdm
 from pliers import config
 from pliers.support.exceptions import MissingDependencyError
@@ -20,7 +20,7 @@ def listify(obj):
 def flatten(l):
     ''' Flatten an iterable. '''
     for el in l:
-        if isinstance(el, collections.Iterable) and not isinstance(el, string_types):
+        if isinstance(el, collections.Iterable) and not isinstance(el, str):
             for sub in flatten(el):
                 yield sub
         else:

--- a/pliers/utils/base.py
+++ b/pliers/utils/base.py
@@ -3,7 +3,6 @@
 import collections
 import os
 from abc import ABCMeta, abstractmethod, abstractproperty
-from six with_metaclass
 from tqdm import tqdm
 from pliers import config
 from pliers.support.exceptions import MissingDependencyError
@@ -135,7 +134,7 @@ class EnvironmentKeyMixin(object):
         return all([k in os.environ for k in cls.env_keys])
 
 
-class APIDependent(with_metaclass(ABCMeta, EnvironmentKeyMixin)):
+class APIDependent(EnvironmentKeyMixin, metaclass=ABCMeta):
 
     _rate_limit = 0
 

--- a/pliers/utils/scikit.py
+++ b/pliers/utils/scikit.py
@@ -3,7 +3,7 @@
 from pliers.extractors import Extractor, merge_results
 from pliers.transformers import get_transformer
 from pliers.utils import attempt_to_import
-from six import string_types
+
 
 sklearn = attempt_to_import('sklearn')
 if sklearn:
@@ -26,7 +26,7 @@ class PliersTransformer(SklearnBase):
     '''
 
     def __init__(self, transformer):
-        if isinstance(transformer, string_types):
+        if isinstance(transformer, str):
             self.transformer = get_transformer(transformer)
         else:
             self.transformer = transformer

--- a/pliers/utils/updater.py
+++ b/pliers/utils/updater.py
@@ -2,13 +2,16 @@
 
 import glob
 import datetime
-import pandas as pd
-import numpy as np
 from os.path import realpath, join, dirname, exists, expanduser
-from pliers.stimuli import load_stims
-from pliers.transformers import get_transformer
 import hashlib
 import pickle
+
+import pandas as pd
+import numpy as np
+
+from pliers.stimuli import load_stims
+from pliers.transformers import get_transformer
+
 
 def hash_data(data, blocksize=65536):
     """" Hashes list of data, strings or data """

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,5 @@ pillow
 requests
 scipy>=0.13
 imageio>=2.3
-six
 tqdm
 psutil

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     maintainer='Tal Yarkoni',
     maintainer_email='tyarkoni@gmail.com',
     url='http://github.com/tyarkoni/pliers',
-    install_requires=['numpy', 'scipy', 'moviepy', 'pandas', 'six',
+    install_requires=['numpy', 'scipy', 'moviepy', 'pandas',
                       'pillow', 'python-magic', 'requests', 'nltk'],
     packages=find_packages(exclude=['pliers/tests']),
     license='MIT',


### PR DESCRIPTION
Closes #391. I probably missed a few things, but `six` is gone, as is `contextlib2`. As a bit of housekeeping, I also put all of the import statements in conventional order (i.e., standard lib, dependencies, then package).