### PR TITLE
Upgrade Python syntax and add python_requires for 3.5+

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 #
 # pliers documentation build configuration file, created by
 # sphinx-quickstart on Wed Dec 27 16:15:14 2017.

--- a/pliers/converters/api/google.py
+++ b/pliers/converters/api/google.py
@@ -41,8 +41,7 @@ class GoogleSpeechAPIConverter(GoogleAPITransformer, AudioToTextConverter):
         self.language_code = language_code
         self.profanity_filter = profanity_filter
         self.speech_contexts = speech_contexts
-        super(GoogleSpeechAPIConverter,
-              self).__init__(discovery_file=discovery_file,
+        super().__init__(discovery_file=discovery_file,
                              api_version=api_version,
                              max_results=max_results,
                              num_retries=num_retries,
@@ -127,8 +126,7 @@ class GoogleVisionAPITextConverter(GoogleVisionAPITransformer,
                  api_version='v1', max_results=100, num_retries=3,
                  rate_limit=None):
         self.handle_annotations = handle_annotations
-        super(GoogleVisionAPITextConverter,
-              self).__init__(discovery_file=discovery_file,
+        super().__init__(discovery_file=discovery_file,
                              api_version=api_version,
                              max_results=max_results,
                              num_retries=num_retries,

--- a/pliers/converters/api/ibm.py
+++ b/pliers/converters/api/ibm.py
@@ -57,7 +57,7 @@ class IBMSpeechAPIConverter(APITransformer, AudioToTextConverter):
         self.password = password
         self.resolution = resolution
         self.model = model
-        super(IBMSpeechAPIConverter, self).__init__(rate_limit=rate_limit)
+        super().__init__(rate_limit=rate_limit)
 
     @property
     def api_keys(self):
@@ -85,13 +85,13 @@ class IBMSpeechAPIConverter(APITransformer, AudioToTextConverter):
             results = _json['results']
         else:
             raise Exception(
-                'received invalid results from API: {0}'.format(str(_json)))
+                'received invalid results from API: {}'.format(str(_json)))
         elements = []
         order = 0
         for result in results:
             if result['final'] is True:
                 timestamps = result['alternatives'][0]['timestamps']
-                if self.resolution is 'words':
+                if self.resolution == 'words':
                     for entry in timestamps:
                         text = entry[0]
                         start = entry[1]
@@ -101,7 +101,7 @@ class IBMSpeechAPIConverter(APITransformer, AudioToTextConverter):
                                                  duration=end-start,
                                                  order=order))
                         order += 1
-                elif self.resolution is 'phrases':
+                elif self.resolution == 'phrases':
                     text = result['alternatives'][0]['transcript']
                     start = timestamps[0][1]
                     end = timestamps[-1][2]
@@ -119,8 +119,8 @@ class IBMSpeechAPIConverter(APITransformer, AudioToTextConverter):
             convert_rate=None if clip.sample_rate >= 16000 else 16000,
             convert_width=None if clip.sample_width >= 2 else 2
         )
-        model = "{0}_BroadbandModel".format(self.model)
-        url = "https://stream.watsonplatform.net/speech-to-text/api/v1/recognize?{0}".format(urlencode({
+        model = "{}_BroadbandModel".format(self.model)
+        url = "https://stream.watsonplatform.net/speech-to-text/api/v1/recognize?{}".format(urlencode({
             "profanity_filter": "false",
             "continuous": "true",
             "model": model,
@@ -136,21 +136,21 @@ class IBMSpeechAPIConverter(APITransformer, AudioToTextConverter):
     def _send_request(self, request):
         if hasattr("", "encode"):  # Python 2.6 compatibility
             authorization_value = base64.standard_b64encode(
-                "{0}:{1}".format(self.username, self.password).encode("utf-8")).decode("utf-8")
+                "{}:{}".format(self.username, self.password).encode("utf-8")).decode("utf-8")
         else:
             authorization_value = base64.standard_b64encode(
-                "{0}:{1}".format(self.username, self.password))
+                "{}:{}".format(self.username, self.password))
         request.add_header(
-            "Authorization", "Basic {0}".format(authorization_value))
+            "Authorization", "Basic {}".format(authorization_value))
 
         try:
             response = urlopen(request, timeout=None)
         except HTTPError as e:
-            raise Exception("recognition request failed: {0}".format(
-                getattr(e, "reason", "status {0}".format(e.code))))
+            raise Exception("recognition request failed: {}".format(
+                getattr(e, "reason", "status {}".format(e.code))))
         except URLError as e:
             raise Exception(
-                "recognition connection failed: {0}".format(e.reason))
+                "recognition connection failed: {}".format(e.reason))
 
         response_text = response.read().decode("utf-8")
         result = json.loads(response_text)

--- a/pliers/converters/api/microsoft.py
+++ b/pliers/converters/api/microsoft.py
@@ -30,8 +30,7 @@ class MicrosoftAPITextConverter(MicrosoftVisionAPITransformer,
     def __init__(self, language='en', subscription_key=None, location=None,
                  api_version='v1.0', rate_limit=None):
         self.language = language
-        super(MicrosoftAPITextConverter,
-              self).__init__(subscription_key=subscription_key,
+        super().__init__(subscription_key=subscription_key,
                              location=location,
                              api_version=api_version,
                              rate_limit=rate_limit)

--- a/pliers/converters/api/revai.py
+++ b/pliers/converters/api/revai.py
@@ -45,7 +45,7 @@ class RevAISpeechAPIConverter(APITransformer, AudioToTextConverter):
         self.timeout = timeout
         self.request_rate = request_rate
         self.client = rev_ai_client.RevAiAPIClient(access_token)
-        super(RevAISpeechAPIConverter, self).__init__()
+        super().__init__()
 
     @property
     def api_keys(self):

--- a/pliers/converters/api/wit.py
+++ b/pliers/converters/api/wit.py
@@ -43,7 +43,7 @@ class SpeechRecognitionAPIConverter(APITransformer, AudioToTextConverter):
                                  " SpeechRecognitionAPIConverter is initialized.")
         self.recognizer = sr.Recognizer()
         self.api_key = api_key
-        super(SpeechRecognitionAPIConverter, self).__init__(rate_limit=rate_limit)
+        super().__init__(rate_limit=rate_limit)
 
     def _convert(self, audio):
         verify_dependencies(['sr'])

--- a/pliers/converters/base.py
+++ b/pliers/converters/base.py
@@ -43,7 +43,7 @@ def get_converter(in_type, out_type, *args, **kwargs):
     default_convs = config.get_option('default_converters')
 
     for ot in out_type:
-        conv_str = '%s->%s' % (in_type.__name__, ot.__name__)
+        conv_str = '{}->{}'.format(in_type.__name__, ot.__name__)
         if conv_str in default_convs:
             convs = list(default_convs[conv_str]) + convs
 

--- a/pliers/converters/multistep.py
+++ b/pliers/converters/multistep.py
@@ -23,7 +23,7 @@ class MultiStepConverter(Converter):
 
     def __init__(self, steps=None):
         self.steps = self._steps if steps is None else steps
-        super(MultiStepConverter, self).__init__()
+        super().__init__()
 
     def _convert(self, stim):
         for i, step in enumerate(self.steps):

--- a/pliers/datasets/text.py
+++ b/pliers/datasets/text.py
@@ -12,7 +12,7 @@ import pandas as pd
 def _load_datasets():
     path = os.path.abspath(__file__)
     path = os.path.join(os.path.dirname(path), 'dictionaries.json')
-    dicts = json.load(io.open(path, encoding='utf-8'))
+    dicts = json.load(open(path, encoding='utf-8'))
     return dicts
 
 datasets = _load_datasets()

--- a/pliers/diagnostics/diagnostics.py
+++ b/pliers/diagnostics/diagnostics.py
@@ -97,7 +97,7 @@ def variances(df):
     return pd.Series(df.var(axis=0), name='Variances')
 
 
-class Diagnostics(object):
+class Diagnostics:
     defaults = {
         'Eigenvalues': (lambda x: x < 0.05),
         'ConditionIndices': (lambda x: x > 20),

--- a/pliers/external/tensorflow/classify_image.py
+++ b/pliers/external/tensorflow/classify_image.py
@@ -31,9 +31,6 @@ to use this script to perform image recognition.
 https://tensorflow.org/tutorials/image_recognition/
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import argparse
 import os.path
@@ -52,7 +49,7 @@ DATA_URL = 'http://download.tensorflow.org/models/image/imagenet/inception-2015-
 # pylint: enable=line-too-long
 
 
-class NodeLookup(object):
+class NodeLookup:
   """Converts integer node ID's to human readable labels."""
 
   def __init__(self,
@@ -164,7 +161,7 @@ def run_inference_on_image(image):
     for node_id in top_k:
       human_string = node_lookup.id_to_string(node_id)
       score = predictions[node_id]
-      print('%s (score = %.5f)' % (human_string, score))
+      print('{} (score = {:.5f})'.format(human_string, score))
 
 
 def maybe_download_and_extract():
@@ -176,7 +173,7 @@ def maybe_download_and_extract():
   filepath = os.path.join(dest_directory, filename)
   if not os.path.exists(filepath):
     def _progress(count, block_size, total_size):
-      sys.stdout.write('\r>> Downloading %s %.1f%%' % (
+      sys.stdout.write('\r>> Downloading {} {:.1f}%'.format(
           filename, float(count * block_size) / float(total_size) * 100.0))
       sys.stdout.flush()
     filepath, _ = urllib.request.urlretrieve(DATA_URL, filepath, _progress)

--- a/pliers/extractors/api/clarifai.py
+++ b/pliers/extractors/api/clarifai.py
@@ -77,7 +77,7 @@ class ClarifaiAPIExtractor(APITransformer):
             select_concepts = listify(select_concepts)
             self.select_concepts = [clarifai_client.Concept(concept_name=n)
                                     for n in select_concepts]
-        super(ClarifaiAPIExtractor, self).__init__(rate_limit=rate_limit)
+        super().__init__(rate_limit=rate_limit)
 
     @property
     def api_keys(self):
@@ -155,8 +155,7 @@ class ClarifaiAPIImageExtractor(ClarifaiAPIExtractor, BatchTransformerMixin,
     def __init__(self, api_key=None, model='general-v1.3', min_value=None,
                  max_concepts=None, select_concepts=None, rate_limit=None,
                  batch_size=None):
-        super(ClarifaiAPIImageExtractor,
-              self).__init__(api_key=api_key,
+        super().__init__(api_key=api_key,
                              model=model,
                              min_value=min_value,
                              max_concepts=max_concepts,

--- a/pliers/extractors/api/google.py
+++ b/pliers/extractors/api/google.py
@@ -195,8 +195,7 @@ class GoogleVideoIntelligenceAPIExtractor(GoogleAPITransformer, VideoExtractor):
         self.config = config
         self.timeout = timeout
         self.request_rate = request_rate
-        super(GoogleVideoIntelligenceAPIExtractor,
-              self).__init__(discovery_file=discovery_file,
+        super().__init__(discovery_file=discovery_file,
                              api_version=api_version,
                              max_results=max_results,
                              num_retries=num_retries,
@@ -354,8 +353,7 @@ class GoogleVideoAPILabelDetectionExtractor(GoogleVideoIntelligenceAPIExtractor)
                 config['labelDetectionConfig']['videoConfidenceThreshold'] = \
                     video_confidence_threshold
 
-        super(GoogleVideoAPILabelDetectionExtractor,
-              self).__init__(features=['LABEL_DETECTION'],
+        super().__init__(features=['LABEL_DETECTION'],
                              segments=segments,
                              config=config,
                              timeout=timeout,
@@ -374,8 +372,7 @@ class GoogleVideoAPIShotDetectionExtractor(GoogleVideoIntelligenceAPIExtractor):
     def __init__(self, segments=None, config=None, timeout=90, request_rate=5,
                  discovery_file=None, api_version='v1', max_results=100,
                  num_retries=3, rate_limit=None):
-        super(GoogleVideoAPIShotDetectionExtractor,
-              self).__init__(features=['SHOT_CHANGE_DETECTION'],
+        super().__init__(features=['SHOT_CHANGE_DETECTION'],
                              segments=segments,
                              config=config,
                              timeout=timeout,
@@ -394,8 +391,7 @@ class GoogleVideoAPIExplicitDetectionExtractor(GoogleVideoIntelligenceAPIExtract
     def __init__(self, segments=None, config=None, timeout=90, request_rate=5,
                  discovery_file=None, api_version='v1', max_results=100,
                  num_retries=3, rate_limit=None):
-        super(GoogleVideoAPIExplicitDetectionExtractor,
-              self).__init__(features=['EXPLICIT_CONTENT_DETECTION'],
+        super().__init__(features=['EXPLICIT_CONTENT_DETECTION'],
                              segments=segments,
                              config=config,
                              timeout=timeout,
@@ -445,8 +441,7 @@ class GoogleLanguageAPIExtractor(GoogleAPITransformer, TextExtractor):
         self.features = features
         self.language = language
         self.is_html = is_html
-        super(GoogleLanguageAPIExtractor,
-              self).__init__(discovery_file=discovery_file,
+        super().__init__(discovery_file=discovery_file,
                              api_version=api_version,
                              max_results=max_results,
                              num_retries=num_retries,
@@ -547,8 +542,7 @@ class GoogleLanguageAPIEntityExtractor(GoogleLanguageAPIExtractor):
     def __init__(self, language=None, is_html=False, discovery_file=None,
                  api_version='v1', max_results=100, num_retries=3,
                  rate_limit=None):
-        super(GoogleLanguageAPIEntityExtractor,
-              self).__init__(features=['extractEntities'],
+        super().__init__(features=['extractEntities'],
                              language=language,
                              is_html=is_html,
                              discovery_file=discovery_file,
@@ -565,8 +559,7 @@ class GoogleLanguageAPISentimentExtractor(GoogleLanguageAPIExtractor):
     def __init__(self, language=None, is_html=False, discovery_file=None,
                  api_version='v1', max_results=100, num_retries=3,
                  rate_limit=None):
-        super(GoogleLanguageAPISentimentExtractor,
-              self).__init__(features=['extractDocumentSentiment'],
+        super().__init__(features=['extractDocumentSentiment'],
                              language=language,
                              is_html=is_html,
                              discovery_file=discovery_file,
@@ -583,8 +576,7 @@ class GoogleLanguageAPISyntaxExtractor(GoogleLanguageAPIExtractor):
     def __init__(self, language=None, is_html=False, discovery_file=None,
                  api_version='v1', max_results=100, num_retries=3,
                  rate_limit=None):
-        super(GoogleLanguageAPISyntaxExtractor,
-              self).__init__(features=['extractSyntax'],
+        super().__init__(features=['extractSyntax'],
                              language=language,
                              is_html=is_html,
                              discovery_file=discovery_file,
@@ -603,8 +595,7 @@ class GoogleLanguageAPITextCategoryExtractor(GoogleLanguageAPIExtractor):
     def __init__(self, language=None, is_html=False, discovery_file=None,
                  api_version='v1', max_results=100, num_retries=3,
                  rate_limit=None):
-        super(GoogleLanguageAPITextCategoryExtractor,
-              self).__init__(features=['classifyText'],
+        super().__init__(features=['classifyText'],
                              language=language,
                              is_html=is_html,
                              discovery_file=discovery_file,
@@ -623,8 +614,7 @@ class GoogleLanguageAPIEntitySentimentExtractor(GoogleLanguageAPIExtractor):
     def __init__(self, language=None, is_html=False, discovery_file=None,
                  api_version='v1', max_results=100, num_retries=3,
                  rate_limit=None):
-        super(GoogleLanguageAPIEntitySentimentExtractor,
-              self).__init__(features=['extractEntitySentiment'],
+        super().__init__(features=['extractEntitySentiment'],
                              language=language,
                              is_html=is_html,
                              discovery_file=discovery_file,

--- a/pliers/extractors/api/microsoft.py
+++ b/pliers/extractors/api/microsoft.py
@@ -49,8 +49,7 @@ class MicrosoftAPIFaceExtractor(MicrosoftAPITransformer, ImageExtractor):
         self.rectangle = rectangle
         self.landmarks = landmarks
         self.attributes = attributes
-        super(MicrosoftAPIFaceExtractor,
-              self).__init__(subscription_key=subscription_key,
+        super().__init__(subscription_key=subscription_key,
                              location=location,
                              api_version=api_version,
                              rate_limit=rate_limit)
@@ -79,14 +78,14 @@ class MicrosoftAPIFaceExtractor(MicrosoftAPITransformer, ImageExtractor):
             if isinstance(v, dict):
                 subdata = self._parse_response_json(v)
                 for sk, sv in subdata.items():
-                    data_dict['%s_%s' % (k, sk)] = sv
+                    data_dict['{}_{}'.format(k, sk)] = sv
             elif isinstance(v, list):
                 # Hard coded to this extractor
                 for attr in v:
                     if k == 'hairColor':
                         key = attr['color']
                     elif k == 'accessories':
-                        key = '%s_%s' % (k, attr['type'])
+                        key = '{}_{}'.format(k, attr['type'])
                     else:
                         continue
                     data_dict[key] = attr['confidence']
@@ -110,8 +109,7 @@ class MicrosoftAPIFaceEmotionExtractor(MicrosoftAPIFaceExtractor):
     def __init__(self, face_id=False, rectangle=False, landmarks=False,
                  subscription_key=None, location=None, api_version='v1.0',
                  rate_limit=None):
-        super(MicrosoftAPIFaceEmotionExtractor,
-              self).__init__(face_id,
+        super().__init__(face_id,
                              rectangle,
                              landmarks,
                              ['emotion'],
@@ -152,8 +150,7 @@ class MicrosoftVisionAPIExtractor(MicrosoftVisionAPITransformer,
         self.features = features if features else ['Tags', 'Categories',
                                                    'ImageType', 'Color',
                                                    'Adult']
-        super(MicrosoftVisionAPIExtractor,
-              self).__init__(subscription_key=subscription_key,
+        super().__init__(subscription_key=subscription_key,
                              location=location,
                              api_version=api_version,
                              rate_limit=rate_limit)
@@ -187,8 +184,7 @@ class MicrosoftVisionAPITagExtractor(MicrosoftVisionAPIExtractor):
 
     def __init__(self, subscription_key=None, location=None, api_version='v1.0',
                  rate_limit=None):
-        super(MicrosoftVisionAPITagExtractor,
-              self).__init__(features=['Tags'],
+        super().__init__(features=['Tags'],
                              subscription_key=subscription_key,
                              location=location,
                              api_version=api_version,
@@ -201,8 +197,7 @@ class MicrosoftVisionAPICategoryExtractor(MicrosoftVisionAPIExtractor):
 
     def __init__(self, subscription_key=None, location=None, api_version='v1.0',
                  rate_limit=None):
-        super(MicrosoftVisionAPICategoryExtractor,
-              self).__init__(features=['Categories'],
+        super().__init__(features=['Categories'],
                              subscription_key=subscription_key,
                              location=location,
                              api_version=api_version,
@@ -215,8 +210,7 @@ class MicrosoftVisionAPIImageTypeExtractor(MicrosoftVisionAPIExtractor):
 
     def __init__(self, subscription_key=None, location=None, api_version='v1.0',
                  rate_limit=None):
-        super(MicrosoftVisionAPIImageTypeExtractor,
-              self).__init__(features=['ImageType'],
+        super().__init__(features=['ImageType'],
                              subscription_key=subscription_key,
                              location=location,
                              api_version=api_version,
@@ -229,8 +223,7 @@ class MicrosoftVisionAPIColorExtractor(MicrosoftVisionAPIExtractor):
 
     def __init__(self, subscription_key=None, location=None, api_version='v1.0',
                  rate_limit=None):
-        super(MicrosoftVisionAPIColorExtractor,
-              self).__init__(features=['Color'],
+        super().__init__(features=['Color'],
                              subscription_key=subscription_key,
                              location=location,
                              api_version=api_version,
@@ -243,8 +236,7 @@ class MicrosoftVisionAPIAdultExtractor(MicrosoftVisionAPIExtractor):
 
     def __init__(self, subscription_key=None, location=None, api_version='v1.0',
                  rate_limit=None):
-        super(MicrosoftVisionAPIAdultExtractor,
-              self).__init__(features=['Adult'],
+        super().__init__(features=['Adult'],
                              subscription_key=subscription_key,
                              location=location,
                              api_version=api_version,

--- a/pliers/extractors/audio.py
+++ b/pliers/extractors/audio.py
@@ -59,7 +59,7 @@ class STFTAudioExtractor(AudioExtractor):
         self.hop_size = hop_size
         self.spectrogram = spectrogram
         self.freq_bins = freq_bins
-        super(STFTAudioExtractor, self).__init__()
+        super().__init__()
 
     def _stft(self, stim):
         x = stim.data
@@ -159,7 +159,7 @@ class LibrosaFeatureExtractor(AudioExtractor, metaclass=ABCMeta):
             self._feature = feature
         self.hop_length = hop_length
         self.librosa_kwargs = librosa_kwargs
-        super(LibrosaFeatureExtractor, self).__init__()
+        super().__init__()
 
     def get_feature_names(self):
         return self._feature
@@ -260,7 +260,7 @@ class SpectralContrastExtractor(LibrosaFeatureExtractor):
 
     def __init__(self, n_bands=6, **kwargs):
         self.n_bands = n_bands
-        super(SpectralContrastExtractor, self).__init__(
+        super().__init__(
             n_bands=n_bands, **kwargs)
 
     def get_feature_names(self):
@@ -290,7 +290,7 @@ class PolyFeaturesExtractor(LibrosaFeatureExtractor):
 
     def __init__(self, order=1, **kwargs):
         self.order = order
-        super(PolyFeaturesExtractor, self).__init__(order=order, **kwargs)
+        super().__init__(order=order, **kwargs)
 
     def get_feature_names(self):
         return ['coefficient_%d' % i for i in range(self.order + 1)]
@@ -373,7 +373,7 @@ class ChromaSTFTExtractor(LibrosaFeatureExtractor):
 
     def __init__(self, n_chroma=12, **kwargs):
         self.n_chroma = n_chroma
-        super(ChromaSTFTExtractor, self).__init__(n_chroma=n_chroma, **kwargs)
+        super().__init__(n_chroma=n_chroma, **kwargs)
 
     def get_feature_names(self):
         return ['chroma_%d' % i for i in range(self.n_chroma)]
@@ -390,7 +390,7 @@ class ChromaCQTExtractor(LibrosaFeatureExtractor):
 
     def __init__(self, n_chroma=12, **kwargs):
         self.n_chroma = n_chroma
-        super(ChromaCQTExtractor, self).__init__(n_chroma=n_chroma, **kwargs)
+        super().__init__(n_chroma=n_chroma, **kwargs)
 
     def get_feature_names(self):
         return ['chroma_cqt_%d' % i for i in range(self.n_chroma)]
@@ -408,7 +408,7 @@ class ChromaCENSExtractor(LibrosaFeatureExtractor):
 
     def __init__(self, n_chroma=12, **kwargs):
         self.n_chroma = n_chroma
-        super(ChromaCENSExtractor, self).__init__(n_chroma=n_chroma, **kwargs)
+        super().__init__(n_chroma=n_chroma, **kwargs)
 
     def get_feature_names(self):
         return ['chroma_cens_%d' % i for i in range(self.n_chroma)]
@@ -425,7 +425,7 @@ class MelspectrogramExtractor(LibrosaFeatureExtractor):
 
     def __init__(self, n_mels=128, **kwargs):
         self.n_mels = n_mels
-        super(MelspectrogramExtractor, self).__init__(n_mels=n_mels, **kwargs)
+        super().__init__(n_mels=n_mels, **kwargs)
 
     def get_feature_names(self):
         return ['mel_%d' % i for i in range(self.n_mels)]
@@ -443,7 +443,7 @@ class MFCCExtractor(LibrosaFeatureExtractor):
 
     def __init__(self, n_mfcc=20, **kwargs):
         self.n_mfcc = n_mfcc
-        super(MFCCExtractor, self).__init__(n_mfcc=n_mfcc, **kwargs)
+        super().__init__(n_mfcc=n_mfcc, **kwargs)
 
     def get_feature_names(self):
         return ['mfcc_%d' % i for i in range(self.n_mfcc)]
@@ -474,7 +474,7 @@ class TempogramExtractor(LibrosaFeatureExtractor):
 
     def __init__(self, win_length=384, **kwargs):
         self.win_length = win_length
-        super(TempogramExtractor, self).__init__(win_length=win_length,
+        super().__init__(win_length=win_length,
                                                  **kwargs)
 
     def get_feature_names(self):
@@ -572,7 +572,7 @@ class AudiosetLabelExtractor(AudioExtractor):
         else:
             self.labels = all_labels
             self.label_idx = list(range(len(all_labels)))
-        super(AudiosetLabelExtractor, self).__init__()
+        super().__init__()
 
     def _extract(self, stim):
         self.params.SAMPLE_RATE = stim.sampling_rate

--- a/pliers/extractors/base.py
+++ b/pliers/extractors/base.py
@@ -16,7 +16,7 @@ class Extractor(Transformer, metaclass=ABCMeta):
     ''' Base class for all pliers Extractors.'''
 
     def transform(self, stim, *args, **kwargs):
-        result = super(Extractor, self).transform(stim, *args, **kwargs)
+        result = super().transform(stim, *args, **kwargs)
         return list(result) if isgenerator(result) else result
 
     @abstractmethod
@@ -31,7 +31,7 @@ class Extractor(Transformer, metaclass=ABCMeta):
                                   "%s." % self.__class__.__name__)
 
 
-class ExtractorResult(object):
+class ExtractorResult:
 
     ''' Stores feature data produced by an Extractor.
 

--- a/pliers/extractors/image.py
+++ b/pliers/extractors/image.py
@@ -114,7 +114,7 @@ class FaceRecognitionFeatureExtractor(ImageExtractor):
         func = getattr(face_recognition.api, self._feature)
         self.func = partial(func, **face_recognition_kwargs)
 
-        super(FaceRecognitionFeatureExtractor, self).__init__()
+        super().__init__()
 
     def get_feature_names(self):
         return self._feature
@@ -146,7 +146,7 @@ class FaceRecognitionFaceLandmarksExtractor(FaceRecognitionFeatureExtractor):
 
     def _to_df(self, result):
         data = pd.DataFrame.from_records(result._data)
-        data.columns = ['%s_%s' % (self._feature, c) for c in data.columns]
+        data.columns = ['{}_{}'.format(self._feature, c) for c in data.columns]
         return data
 
 

--- a/pliers/extractors/models.py
+++ b/pliers/extractors/models.py
@@ -40,7 +40,7 @@ class TensorFlowKerasApplicationExtractor(ImageExtractor):
                  num_predictions=5):
         verify_dependencies(['tensorflow'])
         verify_dependencies(['tensorflow.keras'])
-        super(TensorFlowKerasApplicationExtractor, self).__init__()
+        super().__init__()
 
         # Model name: (model module, model function, required shape).
         apps = tf.keras.applications

--- a/pliers/extractors/text.py
+++ b/pliers/extractors/text.py
@@ -83,7 +83,7 @@ class DictionaryExtractor(TextExtractor):
         self.variables = variables
         # Set up response when key is missing
         self.missing = missing
-        super(DictionaryExtractor, self).__init__()
+        super().__init__()
 
     def _extract(self, stim):
         if stim.text not in self.data.index:
@@ -146,7 +146,7 @@ class PredefinedDictionaryExtractor(DictionaryExtractor):
                 d.index = d.index.str.lower()
             if v:
                 d = d[v]
-            d.columns = ['%s_%s' % (k, c) for c in d.columns]
+            d.columns = ['{}_{}'.format(k, c) for c in d.columns]
             dicts.append(d)
 
         # Make sure none of the dictionaries have duplicate indices
@@ -155,7 +155,7 @@ class PredefinedDictionaryExtractor(DictionaryExtractor):
 
         dictionary = pd.concat(dicts, axis=1, join='outer', sort=False)
 
-        super(PredefinedDictionaryExtractor, self).__init__(
+        super().__init__(
             dictionary, missing=missing)
 
 
@@ -178,7 +178,7 @@ class NumUniqueWordsExtractor(TextExtractor):
     VERSION = '1.0'
 
     def __init__(self, tokenizer=None):
-        super(NumUniqueWordsExtractor, self).__init__()
+        super().__init__()
         self.tokenizer = tokenizer
 
     @requires_nltk_corpus
@@ -251,7 +251,7 @@ class WordEmbeddingExtractor(TextExtractor):
             embedding_file, binary=binary)
         self.prefix = prefix
         self.unk_vector = unk_vector
-        super(WordEmbeddingExtractor, self).__init__()
+        super().__init__()
 
     def _extract(self, stim):
         num_dims = self.wvModel.vector_size
@@ -298,7 +298,7 @@ class TextVectorizerExtractor(BatchTransformerMixin, TextExtractor):
         else:
             self.vectorizer = sklearn_text.CountVectorizer(*vectorizer_args,
                                                            **vectorizer_kwargs)
-        super(TextVectorizerExtractor, self).__init__()
+        super().__init__()
 
     def _extract(self, stims):
         mat = self.vectorizer.fit_transform([s.text for s in stims]).toarray()
@@ -321,7 +321,7 @@ class VADERSentimentExtractor(TextExtractor):
 
     def __init__(self):
         self.analyzer = SentimentIntensityAnalyzer()
-        super(VADERSentimentExtractor, self).__init__()
+        super().__init__()
 
     @requires_nltk_corpus
     def _extract(self, stim):
@@ -355,7 +355,7 @@ class SpaCyExtractor(TextExtractor):
 
         try:
             self.model = spacy.load(model)
-        except (ImportError, IOError, OSError) as e:
+        except (ImportError, OSError) as e:
             logging.warning("Spacy Models ('{}') not found. Downloading and"
                             "installing".format(model))
 
@@ -367,7 +367,7 @@ class SpaCyExtractor(TextExtractor):
         self.features = features
         self.extractor_type = extractor_type.lower()
 
-        super(SpaCyExtractor, self).__init__()
+        super().__init__()
 
     def _extract(self, stim):
 
@@ -462,7 +462,7 @@ class BertExtractor(ComplexTextExtractor):
             pretrained_model, **self.model_kwargs)
         self.tokenizer = transformers.BertTokenizer.from_pretrained(
             tokenizer, **self.tokenizer_kwargs)
-        super(BertExtractor, self).__init__()
+        super().__init__()
 
     def _mask_words(self, wds):
         ''' Called by _preprocess method. Takes list of words in the Stim as
@@ -583,7 +583,7 @@ class BertSequenceEncodingExtractor(BertExtractor):
                     'one of \'[CLS]\', \'[SEP]\' or \'pooler_output\''))
         self.pooling = pooling
         self.return_special = return_special
-        super(BertSequenceEncodingExtractor, self).__init__(
+        super().__init__(
             pretrained_model=pretrained_model, tokenizer=tokenizer, 
             return_input=return_input, model_class='AutoModel', 
             framework=framework, model_kwargs=model_kwargs, 
@@ -676,7 +676,7 @@ class BertLMExtractor(BertExtractor):
                              'are mutually exclusive')
         if type(mask) not in [int, str]:
             raise ValueError('Mask must be a string or an integer.')
-        super(BertLMExtractor, self).__init__(pretrained_model=pretrained_model,
+        super().__init__(pretrained_model=pretrained_model,
             tokenizer=tokenizer, framework=framework, return_input=return_input, 
             model_class='AutoModelWithLMHead', model_kwargs=model_kwargs, 
             tokenizer_kwargs=tokenizer_kwargs)
@@ -783,7 +783,7 @@ class BertSentimentExtractor(BertExtractor):
                  model_kwargs=None,
                  tokenizer_kwargs=None):
         self.return_softmax = return_softmax
-        super(BertSentimentExtractor, self).__init__(
+        super().__init__(
                 pretrained_model=pretrained_model, tokenizer=tokenizer, 
                 framework=framework, return_input=return_input,
                 model_class='AutoModelForSequenceClassification',
@@ -822,7 +822,7 @@ class WordCounterExtractor(ComplexTextExtractor):
         self.log_scale = log_scale
         self.case_sensitive = case_sensitive
         self.features = ['log_word_count'] if self.log_scale else ['word_count']
-        super(WordCounterExtractor, self).__init__()
+        super().__init__()
 
     def _extract(self, stims):
         onsets = [s.onset for s in stims]

--- a/pliers/extractors/video.py
+++ b/pliers/extractors/video.py
@@ -61,7 +61,7 @@ class FarnebackOpticalFlowExtractor(VideoExtractor):
         self.poly_sigma = poly_sigma
         self.flags = flags
         self.show = show
-        super(FarnebackOpticalFlowExtractor, self).__init__()
+        super().__init__()
 
     def _extract(self, stim):
         verify_dependencies(['cv2'])

--- a/pliers/filters/audio.py
+++ b/pliers/filters/audio.py
@@ -42,7 +42,7 @@ class AudioResamplingFilter(AudioFilter):
         self.target_sr = target_sr
         self.resample_type = resample_type
         self.librosa_kwargs = librosa_kwargs
-        super(AudioResamplingFilter, self).__init__()
+        super().__init__()
 
     def _filter(self, stim):
         resampled_stim = deepcopy(stim)

--- a/pliers/filters/base.py
+++ b/pliers/filters/base.py
@@ -50,7 +50,7 @@ class TemporalTrimmingFilter(Filter):
         self.end = end
         self.frames = frames
         self.validation = validation
-        super(TemporalTrimmingFilter, self).__init__()
+        super().__init__()
 
     def _filter(self, stim):
         rate = 'fps' if isinstance(stim, VideoStim) else 'sampling_rate'

--- a/pliers/filters/image.py
+++ b/pliers/filters/image.py
@@ -30,7 +30,7 @@ class ImageCroppingFilter(ImageFilter):
 
     def __init__(self, box=None):
         self.box = box
-        super(ImageCroppingFilter, self).__init__()
+        super().__init__()
 
     def _filter(self, stim):
         if self.box:
@@ -78,7 +78,7 @@ class ImageResizingFilter(ImageFilter):
                 "Unknown resampling method '{}'. Allowed values are '{}'"
                 .format(resample, "', '".join(resampling_mapping.keys())))
         self.resample = resampling_mapping[resample]
-        super(ImageResizingFilter, self).__init__()
+        super().__init__()
 
     def _filter(self, stim):
         pillow_img = Image.fromarray(stim.data)
@@ -142,7 +142,7 @@ class PillowImageFilter(ImageFilter):
             raise ValueError("Must provide an image_filter as a string, type, "
                              "or ImageFilter object. ")
 
-        super(PillowImageFilter, self).__init__()
+        super().__init__()
 
     def _filter(self, stim):
         pillow_img = Image.fromarray(stim.data)

--- a/pliers/filters/text.py
+++ b/pliers/filters/text.py
@@ -67,7 +67,7 @@ class WordStemmingFilter(TextFilter):
         self.stemmer = stemmer
         self.tokenize = tokenize
         self.case_sensitive = case_sensitive
-        super(WordStemmingFilter, self).__init__()
+        super().__init__()
 
     @requires_nltk_corpus
     def _filter(self, stim):
@@ -118,7 +118,7 @@ class TokenizingFilter(TextFilter):
             self.tokenizer = eval(tokenizer)(*args, **kwargs)
         else:
             self.tokenizer = None
-        super(TokenizingFilter, self).__init__()
+        super().__init__()
 
     def _filter(self, stim):
         if self.tokenizer:
@@ -155,7 +155,7 @@ class TokenRemovalFilter(TextFilter):
                 nltk.download('stopwords')
             from nltk.corpus import stopwords
             self.tokens = set(stopwords.words(self.language))
-        super(TokenRemovalFilter, self).__init__()
+        super().__init__()
 
     def _filter(self, stim):
         tokens = word_tokenize(stim.text)

--- a/pliers/filters/video.py
+++ b/pliers/filters/video.py
@@ -39,7 +39,7 @@ class FrameSamplingFilter(Filter):
         self.every = every
         self.hertz = hertz
         self.top_n = top_n
-        super(FrameSamplingFilter, self).__init__()
+        super().__init__()
 
     def _filter(self, video):
         if not isinstance(video, VideoStim):

--- a/pliers/graph.py
+++ b/pliers/graph.py
@@ -14,7 +14,7 @@ pgv = attempt_to_import('pygraphviz', 'pgv')
 stim_list.insert(0, 'ExtractorResult')
 
 
-class Node(object):
+class Node:
 
     ''' A graph node/vertex. Represents a single transformer, optionally with
     references to children.
@@ -57,7 +57,7 @@ class Node(object):
         return spec
 
 
-class Graph(object):
+class Graph:
     ''' Graph-like structure that represents an entire pliers workflow.
 
     Args:

--- a/pliers/stimuli/api.py
+++ b/pliers/stimuli/api.py
@@ -57,7 +57,7 @@ class TweetStimFactory(APIDependent):
         self.consumer_secret = consumer_secret
         self.access_token_key = access_token_key
         self.access_token_secret = access_token_secret
-        super(TweetStimFactory, self).__init__(rate_limit=rate_limit)
+        super().__init__(rate_limit=rate_limit)
 
     @property
     def api_keys(self):
@@ -104,4 +104,4 @@ class TweetStim(CompoundStim):
         if status.media:
             media_stims = load_stims([m.media_url for m in status.media])
             elements.extend(media_stims)
-        super(TweetStim, self).__init__(elements=elements)
+        super().__init__(elements=elements)

--- a/pliers/stimuli/audio.py
+++ b/pliers/stimuli/audio.py
@@ -51,7 +51,7 @@ class AudioStim(Stim):
             # Average channels to make data mono
             self.data = self.data.mean(axis=1)
 
-        super(AudioStim, self).__init__(
+        super().__init__(
             filename, onset=onset, duration=duration, order=order, url=url)
 
     def _load_clip(self):

--- a/pliers/stimuli/base.py
+++ b/pliers/stimuli/base.py
@@ -160,7 +160,7 @@ def load_stims(source, dtype=None, fail_silently=False):
             load_file(s)
         else:
             if not (return_list and fail_silently):
-                raise IOError("File not found")
+                raise OSError("File not found")
 
     if return_list:
         return stims
@@ -201,7 +201,7 @@ def _log_transformation(source, result, trans=None, implicit=False):
         values.append(['', ''])
     parent = source.history
     string = str(parent) if parent else values[2]
-    string += '->%s/%s' % (values[6], values[5])
+    string += '->{}/{}'.format(values[6], values[5])
     values.extend([string, parent])
     values.append(implicit)
     result.history = TransformationLog(*values)

--- a/pliers/stimuli/compound.py
+++ b/pliers/stimuli/compound.py
@@ -7,7 +7,7 @@ from .audio import AudioStim
 from .text import ComplexTextStim
 
 
-class CompoundStim(object):
+class CompoundStim:
 
     ''' A container for an arbitrary set of Stim elements.
 
@@ -36,7 +36,7 @@ class CompoundStim(object):
                 self.elements.append(s)
             else:
                 msg = "Multiple components of same type not allowed, and " + \
-                      "a stim of type %s already exists in this %s." % (stim_cl, self_cl)
+                      "a stim of type {} already exists in this {}.".format(stim_cl, self_cl)
                 raise ValueError(msg)
 
         if self._primary is not None:
@@ -50,8 +50,7 @@ class CompoundStim(object):
 
     def __iter__(self):
         """ Element iteration. """
-        for e in self.elements:
-            yield e
+        yield from self.elements
 
     def get_stim(self, type_, return_all=False):
         ''' Returns component elements of the specified type.
@@ -81,7 +80,7 @@ class CompoundStim(object):
 
     def get_types(self):
         ''' Return tuple of types of all available Stims. '''
-        return tuple(set([e.__class__ for e in self.elements]))
+        return tuple({e.__class__ for e in self.elements})
 
     def has_types(self, types, all_=True):
         ''' Check whether the current component list matches all Stim types
@@ -126,5 +125,5 @@ class TranscribedAudioCompoundStim(CompoundStim):
     _primary = AudioStim
 
     def __init__(self, audio, text):
-        super(TranscribedAudioCompoundStim, self).__init__(
+        super().__init__(
             elements=[audio, text])

--- a/pliers/stimuli/image.py
+++ b/pliers/stimuli/image.py
@@ -40,7 +40,7 @@ class ImageStim(Stim):
             filename = url
         self.data = data
         self._bytestring = None
-        super(ImageStim, self).__init__(filename, onset=onset,
+        super().__init__(filename, onset=onset,
                                         duration=duration, url=url)
 
     def save(self, path):

--- a/pliers/stimuli/text.py
+++ b/pliers/stimuli/text.py
@@ -39,7 +39,7 @@ class TextStim(Stim):
             text = urlopen(url).read()
         self.text = text
         name = 'text[%s]' % text[:40]  # Truncate at 40 chars
-        super(TextStim, self).__init__(filename, onset, duration, order,
+        super().__init__(filename, onset, duration, order,
                                        name=name, url=url)
 
     @property
@@ -108,7 +108,7 @@ class ComplexTextStim(Stim):
             raise ValueError("At least one of the 'filename', 'elements', or "
                              "text arguments must be specified.")
 
-        super(ComplexTextStim, self).__init__(filename, onset, duration)
+        super().__init__(filename, onset, duration)
 
         self._elements = []
 
@@ -181,7 +181,7 @@ class ComplexTextStim(Stim):
             end_ = tuple(row.end)
             duration = self._to_sec(end_) - start_time
 
-            line = re.sub('\s+', ' ', row.text)
+            line = re.sub(r'\s+', ' ', row.text)
             list_[i] = [line, start_time, duration]
 
         # Convert to pandas DataFrame

--- a/pliers/stimuli/video.py
+++ b/pliers/stimuli/video.py
@@ -1,6 +1,5 @@
 ''' Classes that represent video clips. '''
 
-from __future__ import division
 from math import ceil
 
 from moviepy.video.io.VideoFileClip import VideoFileClip
@@ -32,7 +31,7 @@ class VideoFrameStim(ImageStim):
             data = self.video.clip.get_frame(onset)
         if video.onset:
             onset += video.onset
-        super(VideoFrameStim, self).__init__(onset=onset,
+        super().__init__(onset=onset,
                                              duration=duration,
                                              data=data)
         self.name += 'frame[%s]' % frame_num
@@ -75,7 +74,7 @@ class VideoFrameCollectionStim(Stim):
             self.frame_index = range(int(ceil(self.fps * self.clip.duration)))
         duration = self.clip.duration
         self.n_frames = len(self.frame_index)
-        super(VideoFrameCollectionStim, self).__init__(filename,
+        super().__init__(filename,
                                                        onset=onset,
                                                        duration=duration,
                                                        url=url)
@@ -153,7 +152,7 @@ class VideoStim(VideoFrameCollectionStim):
 
     def __init__(self, filename=None, onset=None, url=None, clip=None):
         self._bytestring = None
-        super(VideoStim, self).__init__(filename=filename,
+        super().__init__(filename=filename,
                                         onset=onset,
                                         url=url,
                                         clip=clip)
@@ -169,7 +168,7 @@ class VideoStim(VideoFrameCollectionStim):
         if onset:
             index = int(onset * self.fps)
 
-        return super(VideoStim, self).get_frame(index)
+        return super().get_frame(index)
 
     def get_bytestring(self, encoding='utf-8'):
         ''' Return the video data as a bytestring.

--- a/pliers/support/decorators.py
+++ b/pliers/support/decorators.py
@@ -1,6 +1,4 @@
-
 """Custom decorators."""
-from __future__ import absolute_import
 from functools import wraps
 
 from pliers.support.exceptions import MissingCorpusError

--- a/pliers/support/due.py
+++ b/pliers/support/due.py
@@ -27,7 +27,7 @@ License:    BSD-2
 __version__ = '0.0.5'
 
 
-class InactiveDueCreditCollector(object):
+class InactiveDueCreditCollector:
     """Just a stub at the Collector which would not do anything"""
     def _donothing(self, *args, **kwargs):
         """Perform no good and no bad"""

--- a/pliers/support/exceptions.py
+++ b/pliers/support/exceptions.py
@@ -26,7 +26,7 @@ class MissingCorpusError(PliersError):
     """
 
     def __init__(self, message=MISSING_CORPUS_MESSAGE, *args, **kwargs):
-        super(MissingCorpusError, self).__init__(message, *args, **kwargs)
+        super().__init__(message, *args, **kwargs)
 
 
 class MissingDependencyError(PliersError):
@@ -38,4 +38,4 @@ class MissingDependencyError(PliersError):
     def __init__(self, dependencies, message=MISSING_DEPENDENCY_MESSAGE,
                  custom_message=None, *args, **kwargs):
         msg = custom_message or message % ', '.join(dependencies)
-        super(MissingDependencyError, self).__init__(msg, *args, **kwargs)
+        super().__init__(msg, *args, **kwargs)

--- a/pliers/tests/extractors/api/test_google_extractors.py
+++ b/pliers/tests/extractors/api/test_google_extractors.py
@@ -56,7 +56,7 @@ def test_google_vision_api_face_extractor_inits():
     # Test parsing of individual response
     filename = join(
         get_test_data_path(), 'payloads', 'google_vision_api_face_payload.json')
-    response = json.load(open(filename, 'r'))
+    response = json.load(open(filename))
     stim = ImageStim(join(get_test_data_path(), 'image', 'obama.jpg'))
     res = ExtractorResult(response['faceAnnotations'], stim, ext)
     df = res.to_df()

--- a/pliers/tests/extractors/test_text_extractors.py
+++ b/pliers/tests/extractors/test_text_extractors.py
@@ -1,4 +1,3 @@
-
 from os.path import join
 from pathlib import Path
 from os import environ

--- a/pliers/tests/filters/test_text_filters.py
+++ b/pliers/tests/filters/test_text_filters.py
@@ -95,7 +95,7 @@ def test_tokenizing_filter():
     assert len(sentences) == 11
     assert sentences[0].text == 'To Sherlock Holmes she is always the woman.'
 
-    filt = TokenizingFilter('RegexpTokenizer', '\w+|\$[\d\.]+|\S+')
+    filt = TokenizingFilter('RegexpTokenizer', r'\w+|\$[\d\.]+|\S+')
     tokens = filt.transform(stim)
     assert len(tokens) == 231
     assert tokens[0].text == 'To'

--- a/pliers/tests/test_stims.py
+++ b/pliers/tests/test_stims.py
@@ -193,7 +193,7 @@ def test_complex_stim_from_text():
     assert len(stim.elements) == 231
     stim = ComplexTextStim(text=text, unit='sent')
     # Custom tokenizer
-    stim = ComplexTextStim(text=text, tokenizer='(\w+)')
+    stim = ComplexTextStim(text=text, tokenizer=r'(\w+)')
     assert len(stim.elements) == 209
 
 

--- a/pliers/tests/utils.py
+++ b/pliers/tests/utils.py
@@ -24,7 +24,7 @@ class DummyExtractor(Extractor):
 
     def __init__(self, param_A=None, param_B='pie', name=None, n_rows=100,
                  n_cols=3, max_time=1000):
-        super(DummyExtractor, self).__init__()
+        super().__init__()
         self.param_A = param_A
         self.param_B = param_B
         if name is not None:
@@ -47,7 +47,7 @@ class DummyBatchExtractor(BatchTransformerMixin, Extractor):
 
     def __init__(self, *args, **kwargs):
         self.num_calls = 0
-        super(DummyBatchExtractor, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def _extract(self, stims):
         self.num_calls += 1

--- a/pliers/transformers/api/base.py
+++ b/pliers/transformers/api/base.py
@@ -41,4 +41,4 @@ class APITransformer(APIDependent, Transformer):
                              "you have authorized credentials for accessing "
                              "the target API." % self.__class__.__name__)
 
-        return super(APITransformer, self)._transform(stim, *args, **kwargs)
+        return super()._transform(stim, *args, **kwargs)

--- a/pliers/transformers/api/google.py
+++ b/pliers/transformers/api/google.py
@@ -56,7 +56,7 @@ class GoogleAPITransformer(APITransformer):
         self.max_results = max_results
         self.num_retries = num_retries
         self.api_version = api_version
-        super(GoogleAPITransformer, self).__init__(rate_limit=rate_limit,
+        super().__init__(rate_limit=rate_limit,
                                                    **kwargs)
 
     @property
@@ -87,7 +87,7 @@ class GoogleVisionAPITransformer(GoogleAPITransformer, BatchTransformerMixin):
 
     def __init__(self, discovery_file=None, api_version='v1', max_results=100,
                  num_retries=3, rate_limit=None, batch_size=None):
-        super(GoogleVisionAPITransformer, self).__init__(discovery_file=discovery_file,
+        super().__init__(discovery_file=discovery_file,
                                                          api_version=api_version,
                                                          max_results=max_results,
                                                          num_retries=num_retries,

--- a/pliers/transformers/api/microsoft.py
+++ b/pliers/transformers/api/microsoft.py
@@ -53,7 +53,7 @@ class MicrosoftAPITransformer(APITransformer):
         self.subscription_key = subscription_key
         self.location = location
         self.api_version = api_version
-        super(MicrosoftAPITransformer, self).__init__(rate_limit=rate_limit)
+        super().__init__(rate_limit=rate_limit)
 
     @property
     def api_keys(self):

--- a/pliers/transformers/base.py
+++ b/pliers/transformers/base.py
@@ -42,7 +42,7 @@ class Transformer(metaclass=ABCMeta):
         if name is None:
             name = self.__class__.__name__
         self.name = name
-        super(Transformer, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     def _memoize(transform):
         @wraps(transform)
@@ -229,7 +229,7 @@ class BatchTransformerMixin(Transformer):
     def __init__(self, batch_size=None, *args, **kwargs):
         if batch_size:
             self._batch_size = batch_size
-        super(BatchTransformerMixin, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def _iterate(self, stims, validation='strict', *args, **kwargs):
         batches = batch_iterable(stims, self._batch_size)
@@ -272,14 +272,14 @@ class BatchTransformerMixin(Transformer):
     def _transform(self, stim, *args, **kwargs):
         stims = listify(stim)
         if all(self._stim_matches_input_types(s) for s in stims):
-            result = super(BatchTransformerMixin, self) \
+            result = super() \
                 ._transform(stims, *args, **kwargs)
             if isiterable(stim):
                 return result
             else:
                 return result[0]
         else:
-            return list(super(BatchTransformerMixin, self)
+            return list(super()
                         ._iterate(stims, *args, **kwargs))
 
 

--- a/pliers/utils/base.py
+++ b/pliers/utils/base.py
@@ -22,8 +22,7 @@ def flatten(l):
     ''' Flatten an iterable. '''
     for el in l:
         if isinstance(el, collections.Iterable) and not isinstance(el, str):
-            for sub in flatten(el):
-                yield sub
+            yield from flatten(el)
         else:
             yield el
 
@@ -67,7 +66,7 @@ def set_iterable_type(obj):
         return [set_iterable_type(i) for i in obj]
 
 
-class classproperty(object):
+class classproperty:
     ''' Implements a @classproperty decorator analogous to @classmethod.
     Solution from: http://stackoverflow.com/questions/128573/using-property-on-classmethodss
     '''
@@ -121,7 +120,7 @@ def verify_dependencies(dependencies):
         raise MissingDependencyError(missing)
         
 
-class EnvironmentKeyMixin(object):
+class EnvironmentKeyMixin:
 
     @classproperty
     def _env_keys(cls):
@@ -145,7 +144,7 @@ class APIDependent(EnvironmentKeyMixin, metaclass=ABCMeta):
         self.validated_keys = set()
         self.rate_limit = rate_limit if rate_limit else self._rate_limit
         self._last_request_time = 0
-        super(APIDependent, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     @abstractproperty
     def api_keys(self):

--- a/pliers/utils/scikit.py
+++ b/pliers/utils/scikit.py
@@ -45,9 +45,9 @@ class PliersTransformer(SklearnBase):
             result = merge_results(result, format='wide',
                                    extractor_names=False)
 
-        extra_columns = list(set(['onset', 'duration', 'order', 'history',
+        extra_columns = list({'onset', 'duration', 'order', 'history',
                                   'class', 'filename', 'stim_name',
-                                  'source_file', 'object_id', 'extractor']) &
+                                  'source_file', 'object_id', 'extractor'} &
                              set(result.columns))
         self.metadata_ = result[extra_columns]
         result.drop(extra_columns, axis=1, inplace=True, errors='ignore')

--- a/pliers/utils/updater.py
+++ b/pliers/utils/updater.py
@@ -92,7 +92,7 @@ def check_updates(transformers, datastore=None, stimuli=None):
             if str(obj.__hash__()) == hash_tr:
                 return attr
 
-    delta_t = set([m.split('.')[0] for m in mismatches])
+    delta_t = {m.split('.')[0] for m in mismatches}
     delta_t = [get_trans(dt) for dt in delta_t]
 
     return {'transformers': delta_t, 'mismatches': mismatches}

--- a/setup.py
+++ b/setup.py
@@ -38,4 +38,5 @@ setup(
                 'python-twitter', 'pathos', 'scikit-learn', 'matplotlib',
                 'seaborn', 'pygraphviz', 'xlrd', 'duecredit']
     },
+    python_requires='>=3.5',
 )


### PR DESCRIPTION
Fixes https://github.com/tyarkoni/pliers/issues/391.

* Uses https://github.com/asottile/pyupgrade to upgrade Python syntax for Python 3.5+
* Add `python_requires='>=3.5'` metadata to help pip
