### PR TITLE
Add ExtractorResult --> SeriesStim converter

### DIFF
--- a/pliers/converters/__init__.py
+++ b/pliers/converters/__init__.py
@@ -1,5 +1,6 @@
-''' The `Converter` hierarchy contains Transformer classes that take a `Stim`
-of one type as input and return a `Stim` of a different type as output.
+''' The `Converter` hierarchy contains Transformer classes that take an object
+of arbitrary class (but almost always a `Stim` subclass) as input, and return a
+`Stim` instance (of different class) as output.
 '''
 
 from .api import (WitTranscriptionConverter,
@@ -14,6 +15,8 @@ from .iterators import (VideoFrameIterator, VideoFrameCollectionIterator,
                         ComplexTextIterator)
 from .multistep import VideoToTextConverter, VideoToComplexTextConverter
 from .video import VideoToAudioConverter
+from .misc import ExtractorResultToDFConverter
+
 
 __all__ = [
     'WitTranscriptionConverter',
@@ -29,6 +32,7 @@ __all__ = [
     'VideoToComplexTextConverter',
     'VideoToAudioConverter',
     'RevAISpeechAPIConverter',
+    'ExtractorResultToDFConverter',
     'Converter',
     'get_converter'
 ]

--- a/pliers/converters/__init__.py
+++ b/pliers/converters/__init__.py
@@ -15,7 +15,7 @@ from .iterators import (VideoFrameIterator, VideoFrameCollectionIterator,
                         ComplexTextIterator)
 from .multistep import VideoToTextConverter, VideoToComplexTextConverter
 from .video import VideoToAudioConverter
-from .misc import ExtractorResultToDFConverter
+from .misc import ExtractorResultToSeriesConverter
 
 
 __all__ = [
@@ -32,7 +32,7 @@ __all__ = [
     'VideoToComplexTextConverter',
     'VideoToAudioConverter',
     'RevAISpeechAPIConverter',
-    'ExtractorResultToDFConverter',
+    'ExtractorResultToSeriesConverter',
     'Converter',
     'get_converter'
 ]

--- a/pliers/converters/base.py
+++ b/pliers/converters/base.py
@@ -37,11 +37,10 @@ def get_converter(in_type, out_type, *args, **kwargs):
     '''
     convs = pliers.converters.__all__
 
-    # If config includes default converters for this combination, try them
-    # first
-    out_type = listify(out_type)[::-1]
+    # If config includes default converters for this combination, try them 1st
     default_convs = config.get_option('default_converters')
 
+    out_type = listify(out_type)[::-1]
     for ot in out_type:
         conv_str = '%s->%s' % (in_type.__name__, ot.__name__)
         if conv_str in default_convs:
@@ -52,8 +51,10 @@ def get_converter(in_type, out_type, *args, **kwargs):
         if not inspect.isclass(cls) or not issubclass(cls, Converter):
             continue
 
+        # Some classes are only available if certain environment keys are set
         available = cls.available if issubclass(
             cls, EnvironmentKeyMixin) else True
+
         if cls._input_type == in_type and cls._output_type in out_type \
                 and available:
             conv = cls(*args, **kwargs)

--- a/pliers/converters/misc.py
+++ b/pliers/converters/misc.py
@@ -1,0 +1,14 @@
+"""Miscellaneous conversion classes."""
+
+from pliers.extractors import ExtractorResult
+from pliers.stimuli import DataFrameStim
+from .base import Converter
+
+
+class ExtractorResultToDFConverter(Converter):
+
+    _input_type = ExtractorResult
+    _output_type = DataFrameStim
+
+    def _convert(self, result):
+        pass

--- a/pliers/converters/misc.py
+++ b/pliers/converters/misc.py
@@ -15,11 +15,11 @@ class ExtractorResultToSeriesConverter(Converter):
         df = result.to_df(timing=False, metadata=False, object_id=False)
         n_rows = df.shape[0]
         stims = []
-        for i in n_rows:
+        for i in range(n_rows):
             data = df.iloc[i, :]
-            onset = result.onset[i]
-            duration = result.duration[i]
-            order = result.order[i]
-            st = SeriesStim(data, onset=onset, duration=duration, order=order)
+            onset = result.onset[i] if result.onset is not None else None
+            dur = result.duration[i] if result.duration is not None else None
+            order = result.order[i] if result.order is not None else i
+            st = SeriesStim(data, onset=onset, duration=dur, order=order)
             stims.append(st)
         return stims

--- a/pliers/converters/misc.py
+++ b/pliers/converters/misc.py
@@ -1,14 +1,25 @@
 """Miscellaneous conversion classes."""
 
 from pliers.extractors import ExtractorResult
-from pliers.stimuli import DataFrameStim
+from pliers.stimuli import SeriesStim
 from .base import Converter
 
 
-class ExtractorResultToDFConverter(Converter):
+class ExtractorResultToSeriesConverter(Converter):
+    """Converts an ExtractorResult instance to a list of SeriesStims."""
 
     _input_type = ExtractorResult
-    _output_type = DataFrameStim
+    _output_type = SeriesStim
 
     def _convert(self, result):
-        pass
+        df = result.to_df(timing=False, metadata=False, object_id=False)
+        n_rows = df.shape[0]
+        stims = []
+        for i in n_rows:
+            data = df.iloc[i, :]
+            onset = result.onset[i]
+            duration = result.duration[i]
+            order = result.order[i]
+            st = SeriesStim(data, onset=onset, duration=duration, order=order)
+            stims.append(st)
+        return stims

--- a/pliers/converters/misc.py
+++ b/pliers/converters/misc.py
@@ -13,10 +13,8 @@ class ExtractorResultToSeriesConverter(Converter):
 
     def _convert(self, result):
         df = result.to_df(timing=False, metadata=False, object_id=False)
-        n_rows = df.shape[0]
         stims = []
-        for i in range(n_rows):
-            data = df.iloc[i, :]
+        for i, data in df.iterrows():
             onset = result.onset[i] if result.onset is not None else None
             dur = result.duration[i] if result.duration is not None else None
             order = result.order[i] if result.order is not None else i

--- a/pliers/extractors/base.py
+++ b/pliers/extractors/base.py
@@ -49,9 +49,6 @@ class ExtractorResult(object):
             associated with the rows in data.
         orders (list, ndarray): Optional iterable giving the integer orders
             associated with the rows in data.
-        raw: The raw result (net of any containers or overhead) returned by
-            the underlying feature extraction tool. Can be an object of any
-            type.
     '''
 
     def __init__(self, data, stim, extractor, features=None, onsets=None,

--- a/pliers/stimuli/__init__.py
+++ b/pliers/stimuli/__init__.py
@@ -8,6 +8,7 @@ from .compound import CompoundStim, TranscribedAudioCompoundStim
 from .image import ImageStim
 from .text import TextStim, ComplexTextStim
 from .video import VideoStim, VideoFrameCollectionStim, VideoFrameStim
+from .misc import SeriesStim
 
 
 __all__ = [
@@ -22,5 +23,6 @@ __all__ = [
     'VideoFrameStim',
     'TweetStimFactory',
     'TweetStim',
+    'SeriesStim',
     'load_stims'
 ]

--- a/pliers/stimuli/base.py
+++ b/pliers/stimuli/base.py
@@ -187,7 +187,12 @@ def _log_transformation(source, result, trans=None, implicit=False):
     if isiterable(result):
         return (_log_transformation(source, r, trans) for r in result)
 
-    values = [source.name, source.filename, source.__class__.__name__]
+    # Converters are no longer restricted to Stim inputs, so ensure name and
+    # filename are set.
+    name = getattr(source, 'name', None)
+    filename = getattr(source, 'filename', None)
+
+    values = [name, filename, source.__class__.__name__]
     if isinstance(result, Stim):
         values.extend([result.name, result.filename])
     else:

--- a/pliers/stimuli/misc.py
+++ b/pliers/stimuli/misc.py
@@ -38,7 +38,7 @@ class SeriesStim(Stim):
             if filename is None and url is None:
                 raise ValueError("No data provided! One of the data, filename,"
                                  "or url arguments must be passed.")
-            source = data or url
+            source = filename or url
             data = pd.read_csv(source, squeeze=True, **pd_args)
             if isinstance(data, pd.DataFrame):
                 if column is None:

--- a/pliers/stimuli/misc.py
+++ b/pliers/stimuli/misc.py
@@ -51,5 +51,11 @@ class SeriesStim(Stim):
         self.data = data
         super().__init__(filename, onset, duration, order, name)
 
-    def save(self, path):
-        self.data.to_csv(path)
+    def save(self, path, **kwargs):
+        """Save stored series to disk.
+
+        Args:
+            path (str): The path of the file to save to.
+            kwargs: Optional keyword arguments passed to pandas' to_csv()
+        """
+        self.data.to_csv(path, **kwargs)

--- a/pliers/stimuli/misc.py
+++ b/pliers/stimuli/misc.py
@@ -1,0 +1,55 @@
+"""Miscellaneous Stim classes."""
+
+import numpy as np
+import pandas as pd
+
+from .base import Stim
+
+
+class SeriesStim(Stim):
+    '''Represents a pandas Series as a pliers Stim.
+
+    Args:
+        data (dict, pd.Series, array-like): A dictionary, pandas Series, or any
+            other iterable (e.g., list or 1-D numpy array) that can be coerced
+            to a pandas Series.
+        filename (str, optional): Path or URL to data file. Must be readable
+            using pd.read_csv().
+        onset (float): Optional onset of the SeriesStim (in seconds) with
+            respect to some more general context or timeline the user wishes
+            to keep track of.
+        duration (float): Optional duration of the SeriesStim, in seconds.
+        order (int): Optional order of stim within some broader context.
+        url (str): Optional URL to read data from. Must be readable using
+            pd.read_csv().
+        column (str): If filename or url is passed, defines the name of the
+            column in the data source to read in as data.
+        name (str): Optional name to give the SeriesStim instance. If None
+            is provided, the name will be derived from the filename if one is
+            defined. If no filename is defined, name will be an empty string.
+        pd_args: Optional keyword arguments passed onto pd.read_csv() (e.g., 
+            to control separator, header, etc.).
+    '''
+
+    def __init__(self, data=None, filename=None, onset=None, duration=None,
+                 order=None, url=None, column=None, name=None, **pd_args):
+
+        if data is None:
+            if filename is None and url is None:
+                raise ValueError("No data provided! One of the data, filename,"
+                                 "or url arguments must be passed.")
+            source = data or url
+            data = pd.read_csv(source, squeeze=True, **pd_args)
+            if isinstance(data, pd.DataFrame):
+                if column is None:
+                    raise ValueError("Data source contains more than one "
+                                    "column; please specify which column to "
+                                    "use by passing the 'column' argument.")
+                data = data.loc[:, column]
+        
+        data = pd.Series(data)
+        self.data = data
+        super().__init__(filename, onset, duration, order, name)
+
+    def save(self, path):
+        self.data.to_csv(path)

--- a/pliers/tests/converters/test_converters.py
+++ b/pliers/tests/converters/test_converters.py
@@ -7,10 +7,12 @@ from pliers.converters import (get_converter,
                                VideoToAudioConverter,
                                VideoToTextConverter,
                                WitTranscriptionConverter,
-                               ComplexTextIterator)
+                               ComplexTextIterator,
+                               ExtractorResultToSeriesConverter)
 from pliers.converters.image import ImageToTextConverter
-from pliers.stimuli import (VideoStim, TextStim,
+from pliers.stimuli import (VideoStim, TextStim, SeriesStim,
                             ComplexTextStim, ImageStim)
+from pliers.extractors import ExtractorResult
 
 
 def test_get_converter():
@@ -53,3 +55,18 @@ def test_stim_iteration_converter():
     assert words[1].text == 'Sherlock'
     assert str(
         words[1].history) == 'ComplexTextStim->ComplexTextIterator/TextStim'
+
+
+def test_extractor_result_to_series_converter():
+    data = [[2, 4], [1, 7], [6, 6], [8, 2]]
+    result = ExtractorResult(data, None, None, features=['a', 'b'],
+                             onsets=[2, 4, 6, 8])
+    stims = ExtractorResultToSeriesConverter().transform(result)
+    assert len(stims) == 4
+    stim = stims[2]
+    assert isinstance(stim, SeriesStim)
+    assert stim.data.shape == (2,)
+    assert list(stim.data) == [6, 6]
+    assert stim.onset == 6
+    assert stim.duration is None
+    assert stim.order == 2


### PR DESCRIPTION
This PR adds an `ExtractorResultToSeriesConverter` class that converts an `ExtractorResult` instance into a list of `SeriesStim` instances. The `SeriesStim` is also new, and is just a wrapper around a pandas `Series`. This allows us to build extractors that operate on the outputs of other extractors (e.g., to compute summary statistics over multiple columns). It's a bit inelegant in that it required a bit (but only a bit) of *sui generis* handling of `ExtractorResult` inputs (since we can otherwise assume `Transformer` inputs are always `Stim` subclasses), but I think it's a small price to pay for the added flexibility.

@rbroc, in principle, the existing automatic conversion detection should kick in without having to do anything further, so any `Extractor` that specifies a `SeriesStim` input type *should* be able to take an `ExtractorResult` as input to `transform()`. But I haven't tested this yet, so let me know if you run into problems.

Note that I ended up splitting the `ExtractorResult` DFs into a separate `SeriesStim` for each row after all (much like your `VectorStim`), as there would otherwise have been some thorny issues to deal with. Also, there isn't really any way I can see to distinguish between "good" and "bad" features on the `Stim` side of things; I think this will need to be built into the `MetricExtractor` hierarchy, unless we want to rework the `ExtractorResult` class to have some concept of metadata (that's aspirational, but probably not happening any time soon). For example, for the BertLM extractor, if you leave metadata on, you're going to get not only one column per prediction, but also a "sequence" column. The extractor will then need to have some way of knowing which features to ignore—perhaps by taking this as an initialization argument. I also don't currently do any checking for data type, which is likely to be problematic. But again I would prefer to do this on the extractor side rather than the conversion/stim side, as there could be principled reasons for wanting to retain, e.g., string columns in the `SeriesStim`, even if most extractors don't know what to do with that.