### PR TITLE
fix labels indexing issue in Audioset extractor

### DIFF
--- a/pliers/extractors/audio.py
+++ b/pliers/extractors/audio.py
@@ -10,8 +10,6 @@ from scipy import fft
 import pandas as pd
 import soundfile as sf
 
-import logging
-
 from pliers.stimuli.audio import AudioStim
 from pliers.stimuli.text import ComplexTextStim
 from pliers.extractors.base import Extractor, ExtractorResult

--- a/pliers/extractors/audio.py
+++ b/pliers/extractors/audio.py
@@ -602,7 +602,6 @@ class AudiosetLabelExtractor(AudioExtractor):
         model = self.yamnet.yamnet_frames_model(self.params)
         model.load_weights(self.weights_path)
         preds, _ = model.predict_on_batch(np.reshape(stim.data, [1,-1]))
-        preds = preds.numpy()
         preds = preds[:,self.label_idx]
         
         nr_lab = self.top_n or len(self.labels)


### PR DESCRIPTION
Fixing a bug that caused mismatch between labels and values when passing subset of AudioSet labels to AudioSet extractor.